### PR TITLE
Added kernel extension SPI

### DIFF
--- a/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.core.internal;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.reflect.TypeToken;
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.spi.KernelExtension;
+
+import java.util.*;
+
+/**
+ * The ExtensionManager handles the kernel extensions.
+ *
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+@SuppressWarnings("unchecked")
+public class ExtensionManager
+{
+
+    private final List<Plugin>                         fetchedPlugins;
+    private final ClassLoader                          contextClassLoader;
+    private final Multimap<KernelExtension<?>, Plugin> kernelExtensions = ArrayListMultimap.create();
+
+    /**
+     * Constructor.
+     *
+     * @param fetchedPlugins the plugin list
+     */
+    public ExtensionManager(List<Plugin> fetchedPlugins, ClassLoader contextClassLoader)
+    {
+        this.fetchedPlugins = fetchedPlugins;
+        this.contextClassLoader = contextClassLoader;
+
+        fetchExtensions();
+    }
+
+    private void fetchExtensions()
+    {
+
+        ServiceLoader<KernelExtension> kernelExtensionLoader = ServiceLoader.load(KernelExtension.class, contextClassLoader);
+        Map<Class<?>, KernelExtension<?>> extensionMapping = new HashMap<Class<?>, KernelExtension<?>>();
+        for (KernelExtension<?> kernelExtension : kernelExtensionLoader)
+        {
+            Class<?> extensionInterface = TypeToken.of(kernelExtension.getClass()).resolveType(KernelExtension.class.getTypeParameters()[0]).getRawType();
+            extensionMapping.put(extensionInterface, kernelExtension);
+        }
+
+        for (Plugin plugin : fetchedPlugins)
+        {
+            for (Class<?> anInterface : plugin.getClass().getInterfaces())
+            {
+                if(extensionMapping.containsKey(anInterface))
+                {
+                    KernelExtension<?> kernelExtension = extensionMapping.get(anInterface);
+
+                    kernelExtensions.put(kernelExtension, plugin);
+                }
+            }
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is initializing
+     */
+    public void initializing()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            Collection<Plugin> plugins = kernelExtensions.get(kernelExtension);
+            kernelExtension.initializing(plugins);
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is initialized
+     */
+    public void initialized()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.initialized(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is starting
+     */
+    public void starting()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.starting(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is started
+     */
+    public void started()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.started(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is stopping
+     */
+    public void stopping()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.stopping(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
+     * Notifies the extensions that the kernel is stopped
+     */
+    public void stopped()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.stopped(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
+     * Gets enabled extensions.
+     *
+     * @return set of kernel extensions
+     */
+    public Set<KernelExtension<?>> getExtensions()
+    {
+        return kernelExtensions.keySet();
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.core.pluginsit.extension.DummyExtensionPlugin;
+import io.nuun.kernel.core.pluginsit.extension.MyKernelExtension;
+import io.nuun.kernel.spi.KernelExtension;
+import org.fest.assertions.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public class ExtensionManagerTest
+{
+
+    private ExtensionManager underTest;
+
+    @Before
+    public void setup()
+    {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        plugins.add(new DummyExtensionPlugin());
+        underTest = new ExtensionManager(plugins, Thread.currentThread().getContextClassLoader());
+    }
+
+    @Test
+    public void kernel_extension_should_be_called()
+    {
+        Assertions.assertThat(underTest.getExtensions()).hasSize(1);
+
+        KernelExtension kernelExtension = underTest.getExtensions().iterator().next();
+        Assertions.assertThat(kernelExtension).isInstanceOf(MyKernelExtension.class);
+
+        MyKernelExtension myKernelExtension = (MyKernelExtension) kernelExtension;
+        Assertions.assertThat(myKernelExtension.count).isEqualTo(0);
+
+        underTest.initializing();
+        underTest.initialized();
+        underTest.starting();
+        underTest.started();
+        underTest.stopping();
+        underTest.stopped();
+
+        Assertions.assertThat(myKernelExtension.count).isEqualTo(111111);
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/DummyExtensionPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/DummyExtensionPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.core.pluginsit.extension;
+
+import io.nuun.kernel.core.AbstractPlugin;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ *         05/01/2015
+ */
+public class DummyExtensionPlugin extends AbstractPlugin implements MyExtensionInterface {
+
+    @Override
+    public String name() {
+        return "dummy-extension-plugin";
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyExtensionInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyExtensionInterface.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.core.pluginsit.extension;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ *         05/01/2015
+ */
+public interface MyExtensionInterface {
+}

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.core.pluginsit.extension;
+
+import io.nuun.kernel.spi.KernelExtension;
+
+import java.util.Collection;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ *         05/01/2015
+ */
+public class MyKernelExtension implements KernelExtension<MyExtensionInterface> {
+
+    public int count = 0;
+
+    @Override
+    public void initializing(Collection<MyExtensionInterface> extensions) {
+        count += 1;
+    }
+
+    @Override
+    public void initialized(Collection<MyExtensionInterface> extensions) {
+        count += 10;
+    }
+
+    @Override
+    public void starting(Collection<MyExtensionInterface> extensions) {
+        count += 100;
+    }
+
+    @Override
+    public void started(Collection<MyExtensionInterface> extensions) {
+        count += 1000;
+    }
+
+    @Override
+    public void stopping(Collection<MyExtensionInterface> extensions) {
+        count += 10000;
+    }
+
+    @Override
+    public void stopped(Collection<MyExtensionInterface> extensions) {
+        count += 100000;
+    }
+}

--- a/core/src/test/resources/META-INF/services/io.nuun.kernel.spi.KernelExtension
+++ b/core/src/test/resources/META-INF/services/io.nuun.kernel.spi.KernelExtension
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+#
+# Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+# or any later version
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.gnu.org/licenses/lgpl-3.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.nuun.kernel.core.pluginsit.extension.MyKernelExtension

--- a/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.nuun.kernel.spi;
+
+import java.util.Collection;
+
+/**
+ * Kernel extensions provide an SPI to enhanced the kernel behavior.
+ * <p>
+ * To create a kernel extension, create a class which implements the {@code KernelExtension} interface. And a marker
+ * interface associated to the extension as follows:
+ * </p>
+ * <pre>
+ * class MyFeatureExtension implements KernelExtension{@literal <MyFeature>} {...}
+ *
+ * interface MyFeature {...}
+ * </pre>
+ * <p>
+ * Then, create a plugin implementing the extension marker.
+ * </p>
+ * <pre>
+ * class MyPlugin extends AbstractPlugin implements MyFeature {...}
+ * </pre>
+ * <p>
+ * The kernel extension will be called at each step of the kernel lifecycle (initializing, initialized, starting, etc.).
+ * The list of plugin implementing the kernel extension marker will be passed to the kernel extension at each method call.
+ * </p>
+ * @param <T> the kernel extension marker to be implemented by plugins.
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public interface KernelExtension<T>
+{
+    /**
+     * Notifies the given extension that the kernel is initializing.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void initializing(Collection<T> extendedPlugins);
+
+    /**
+     * Notifies the given extension that the kernel is initialized.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void initialized(Collection<T> extendedPlugins);
+
+    /**
+     * Notifies the given extension that the kernel is starting.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void starting(Collection<T> extendedPlugins);
+
+    /**
+     * Notifies the given extension that the kernel is started.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void started(Collection<T> extendedPlugins);
+
+    /**
+     * Notifies the given extension that the kernel is stopping.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void stopping(Collection<T> extendedPlugins);
+
+    /**
+     * Notifies the given extension that the kernel is stopped.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void stopped(Collection<T> extendedPlugins);
+}


### PR DESCRIPTION
Kernel extensions provide an SPI to enhanced the kernel behavior.

To create a kernel extension, create a class which implements the `KernelExtension` interface. And a marker interface associated to the extension as follows:

     class MyFeatureExtension implements KernelExtension<MyFeature> {...}

    interface MyFeature {...}

Then, create a plugin implementing the extension marker.

    class MyPlugin extends AbstractPlugin implements MyFeature {...}

The kernel extension will be called at each step of the kernel lifecycle (initializing, initialized, starting, etc.).
The list of plugin implementing the kernel extension marker will be passed to the kernel extension at each method call.