### PR TITLE
Fix ignore policy

### DIFF
--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/AbstractClasspathScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/AbstractClasspathScanner.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Collections2;
 
 /**
  *
- *
+ * 
  * @author epo.jemba{@literal @}kametic.com
  *
  */
@@ -107,7 +107,7 @@ public abstract class AbstractClasspathScanner implements ClasspathScanner
 	            for (Annotation annotation : clazz.getAnnotations())
 	            {
 	                logger.trace("Checking annotation {} for Ignore", annotation.annotationType().getName());
-	                if (annotation.annotationType().equals(Ignore.class) || annotation.annotationType().getName().endsWith("Ignore"))
+	                if (annotation.annotationType().equals(Ignore.class) || annotation.annotationType().getAnnotation(Ignore.class) != null)
 	                {
 	                    toKeep = false;
 	                }

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/IgnorePolicyTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/IgnorePolicyTest.java
@@ -1,0 +1,45 @@
+package io.nuun.kernel.core.internal.scanner;
+
+import io.nuun.kernel.api.annotations.Ignore;
+import org.fest.assertions.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Pierre Thirouin
+ *         Date: 08/06/15
+ */
+public class IgnorePolicyTest {
+
+    private AbstractClasspathScanner.IgnorePredicate ignorePredicate;
+
+    @Before
+    public void testIgnore() {
+        ignorePredicate = new AbstractClasspathScanner.IgnorePredicate(false);
+    }
+
+    @Test
+    public void testIgnorePredicate() {
+        Assertions.assertThat(ignorePredicate.apply(IgnorePolicyTest.class)).isTrue();
+        Assertions.assertThat(ignorePredicate.apply(IgnoredClass1.class)).isFalse();
+        Assertions.assertThat(ignorePredicate.apply(IgnoredClass2.class)).isFalse();
+    }
+
+    static class NormalClass {}
+
+    @Ignore
+    static class IgnoredClass1 {}
+
+    @CustomIgnore
+    static class IgnoredClass2 {}
+
+    @Ignore
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    static @interface CustomIgnore {}
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Ignore.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Ignore.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@io.nuun.kernel.api.annotations.Ignore
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE})
 public @interface Ignore


### PR DESCRIPTION
Replace ignore policy based on class name:

    annotation.annotationType().getName().endsWith("Ignore")

by meta annotation:

    annotation.annotationType().getAnnotation(Ignore.class) != null

Fixes #34 