### PR TITLE
Remove destroy method

### DIFF
--- a/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
+++ b/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
@@ -25,35 +25,20 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.RoundEnvironment;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
-import io.nuun.kernel.api.plugin.request.BindingRequest;
-import io.nuun.kernel.api.plugin.request.BindingRequestBuilder;
-import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
-import io.nuun.kernel.api.plugin.request.ClasspathScanRequestBuilder;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequestBuilder;
+import io.nuun.kernel.api.plugin.request.*;
 import io.nuun.kernel.api.plugin.request.builders.BindingRequestBuilderMain;
 import io.nuun.kernel.core.internal.ModuleEmbedded;
 import io.nuun.kernel.spi.DependencyInjectionProvider;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-import org.kametic.specifications.AbstractSpecification;
-import org.kametic.specifications.AndSpecification;
-import org.kametic.specifications.NotSpecification;
-import org.kametic.specifications.OrSpecification;
-import org.kametic.specifications.Specification;
+import org.kametic.specifications.*;
 import org.kametic.specifications.reflect.ClassMethodsAnnotatedWith;
 import org.kametic.specifications.reflect.DescendantOfSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.*;
 
 /**
  * @author Epo Jemba
@@ -108,11 +93,6 @@ public abstract class AbstractPlugin implements Plugin
     public void start(Context context)
     {
         this.context = context;
-    }
-
-    @Override
-    public void destroy()
-    {
     }
 
     // /**

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
@@ -170,11 +170,6 @@ public class DummyPlugin extends AbstractPlugin
     }
 
     @Override
-    public void destroy()
-    {
-    }
-
-    @Override
     public void start(Context context)
     {
         assertThat(context).isNotNull();

--- a/specs/src/main/java/io/nuun/kernel/api/Plugin.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Plugin.java
@@ -52,11 +52,6 @@ public interface Plugin
     void stop();
 
     /**
-     * Lifecycle method: destroy()
-     */
-    void destroy();
-
-    /**
      * The name of the plugin. Plugin won't be installed, if there is no a name. And if this name is not
      * unique. Mandatory.
      * 

--- a/specs/src/test/java/io/nuun/kernel/api/plugin/request/annotations/TestPlugin.java
+++ b/specs/src/test/java/io/nuun/kernel/api/plugin/request/annotations/TestPlugin.java
@@ -22,24 +22,13 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.RoundEnvironment;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
-import io.nuun.kernel.api.plugin.request.BindingRequest;
-import io.nuun.kernel.api.plugin.request.BindingRequestBuilder;
-import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
-import io.nuun.kernel.api.plugin.request.ClasspathScanRequestBuilder;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequestBuilder;
+import io.nuun.kernel.api.plugin.request.*;
 import io.nuun.kernel.spi.DependencyInjectionProvider;
-
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.*;
 
 /**
  * @author epo.jemba{@literal @}kametic.com
@@ -90,11 +79,6 @@ public abstract class TestPlugin implements Plugin
     public void start(Context context)
     {
         this.context = context;
-    }
-
-    @Override
-    public void destroy()
-    {
     }
 
     // /**


### PR DESCRIPTION
Remove the lifecycle method destroy which was unused in plugins and unimplemented in the kernel.

Thie PR is based on #39 and should merged after.