### PR TITLE
Allow plugin to expose interfaces called facets

### DIFF
--- a/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
+++ b/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
@@ -209,13 +209,13 @@ public abstract class AbstractPlugin implements Plugin
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins()
+    public Collection<Class<?>> requiredPlugins()
     {
         return Collections.emptySet();
     }
     
     @Override
-    public Collection<Class<? extends Plugin>> dependentPlugins()
+    public Collection<Class<?>> dependentPlugins()
     {
         return Collections.emptySet();
     }
@@ -298,11 +298,6 @@ public abstract class AbstractPlugin implements Plugin
     public Map<String, String> kernelParametersAliases()
     {
         return new HashMap<String, String>();
-    }
-
-    protected Collection<Class<? extends Plugin>> collectionOf(Class<? extends Plugin>... items)
-    {
-        return Arrays.asList(items);
     }
     
     protected UnitModule unitModule(Object module)

--- a/core/src/main/java/io/nuun/kernel/core/internal/ContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ContextInternal.java
@@ -28,7 +28,7 @@ import javax.inject.Singleton;
  * 
  */
 @Singleton
-public class ContextInternal implements Context
+class ContextInternal implements Context
 {
 
     public final Injector mainInjector;

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
@@ -14,7 +14,7 @@ import java.util.List;
  *
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
-public class DependencyProvider {
+class DependencyProvider {
 
     private final PluginRegistry pluginRegistry;
     private final FacetRegistry facetRegistry;
@@ -71,10 +71,19 @@ public class DependencyProvider {
     }
 
     public <T> List<T> getFacets(Class<? extends Plugin> pluginClass, Class<T> facet) {
+        assertExplicitDependency(pluginClass, facet);
+        return facetRegistry.getFacets(facet);
+    }
+
+    public <T> T getFacet(Class<? extends Plugin> pluginClass, Class<T> facet) {
+        assertExplicitDependency(pluginClass, facet);
+        return facetRegistry.getFacet(facet);
+    }
+
+    private <T> void assertExplicitDependency(Class<? extends Plugin> pluginClass, Class<T> facet) {
         Plugin plugin = pluginRegistry.get(pluginClass);
         if (!plugin.requiredPlugins().contains(facet) && !plugin.dependentPlugins().contains(facet)) {
             throw new KernelException("The plugin " + pluginClass.getCanonicalName() + " doesn't specify a dependency with " + facet.getCanonicalName());
         }
-        return facetRegistry.getFacets(facet);
     }
 }

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
@@ -1,0 +1,80 @@
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.core.KernelException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class allows to retrieve a plugin's required or dependent dependencies.
+ * A dependency can be a {@link io.nuun.kernel.api.annotations.Facet} interface or a
+ * {@link io.nuun.kernel.api.Plugin} class.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class DependencyProvider {
+
+    private final PluginRegistry pluginRegistry;
+    private final FacetRegistry facetRegistry;
+
+
+
+    private static enum DependencyType {
+        REQUIRED, DEPENDENT, ALL;
+    }
+    public DependencyProvider(PluginRegistry pluginRegistry) {
+        this(pluginRegistry, new FacetRegistry(pluginRegistry.getPlugins()));
+    }
+
+    public DependencyProvider(PluginRegistry pluginRegistry, FacetRegistry facetRegistry) {
+        this.pluginRegistry = pluginRegistry;
+        this.facetRegistry = facetRegistry;
+    }
+
+    public List<Plugin> getAll(Class<? extends Plugin> pluginClass) {
+        return getDependency(pluginClass, DependencyType.ALL);
+    }
+
+    public List<Plugin> getRequired(Class<? extends Plugin> pluginClass) {
+        return getDependency(pluginClass, DependencyType.REQUIRED);
+    }
+
+    public List<Plugin> getDependent(Class<? extends Plugin> pluginClass) {
+        return getDependency(pluginClass, DependencyType.DEPENDENT);
+    }
+
+    private List<Plugin> getDependency(Class<? extends Plugin> pluginClass, DependencyType dependencyType) {
+        Plugin plugin = pluginRegistry.get(pluginClass);
+        List<Plugin> dependencies = new ArrayList<Plugin>();
+        if (plugin != null) {
+            for (Class<?> requiredClass : getDependencyClasses(plugin, dependencyType)) {
+                //noinspection unchecked
+                dependencies.addAll((Collection<? extends Plugin>) facetRegistry.getFacets(requiredClass));
+            }
+        }
+        return dependencies;
+    }
+
+    private Collection<Class<?>> getDependencyClasses(Plugin plugin, DependencyType dependencyType) {
+        Collection<Class<?>> requiredClasses = new ArrayList<Class<?>>();
+        if (dependencyType.equals(DependencyType.REQUIRED)) {
+            requiredClasses = plugin.requiredPlugins();
+        } else if (dependencyType.equals(DependencyType.DEPENDENT)) {
+            requiredClasses = plugin.dependentPlugins();
+        } else if (dependencyType.equals(DependencyType.ALL)) {
+            requiredClasses = plugin.requiredPlugins();
+            requiredClasses.addAll(plugin.dependentPlugins());
+        }
+        return requiredClasses;
+    }
+
+    public <T> List<T> getFacets(Class<? extends Plugin> pluginClass, Class<T> facet) {
+        Plugin plugin = pluginRegistry.get(pluginClass);
+        if (!plugin.requiredPlugins().contains(facet) && !plugin.dependentPlugins().contains(facet)) {
+            throw new KernelException("The plugin " + pluginClass.getCanonicalName() + " doesn't specify a dependency with " + facet.getCanonicalName());
+        }
+        return facetRegistry.getFacets(facet);
+    }
+}

--- a/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
@@ -34,7 +34,7 @@ import java.util.*;
 public class ExtensionManager
 {
 
-    private final List<Plugin>                         fetchedPlugins;
+    private final Collection<Plugin>                         fetchedPlugins;
     private final ClassLoader                          contextClassLoader;
     private final Multimap<KernelExtension<?>, Plugin> kernelExtensions = ArrayListMultimap.create();
 
@@ -43,7 +43,7 @@ public class ExtensionManager
      *
      * @param fetchedPlugins the plugin list
      */
-    public ExtensionManager(List<Plugin> fetchedPlugins, ClassLoader contextClassLoader)
+    public ExtensionManager(Collection<Plugin> fetchedPlugins, ClassLoader contextClassLoader)
     {
         this.fetchedPlugins = fetchedPlugins;
         this.contextClassLoader = contextClassLoader;

--- a/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
@@ -1,0 +1,95 @@
+package io.nuun.kernel.core.internal;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.api.annotations.Facet;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+/**
+ * This registry takes a list of plugins and extracts all its facets.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+class FacetRegistry {
+
+    private final ListMultimap<Class<?>, Plugin> facets = ArrayListMultimap.create();
+    private final Map<Class<?>, Plugin> plugins = new HashMap<Class<?>, Plugin>();
+
+    /**
+     * Constructs a facet registry.
+     *
+     * @param plugins the list of plugin
+     */
+    FacetRegistry(final Collection<Plugin> plugins) {
+        if (plugins != null) {
+            for (Plugin plugin : plugins) {
+                this.plugins.put(plugin.getClass(), plugin);
+
+                for (Class<?> anInterface : plugin.getClass().getInterfaces()) {
+                    if (isFacet(anInterface)) {
+                        facets.put(anInterface, plugin);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the plugin implementing the given facet.
+     * <p>
+     * In order to provide more flexibility, the given class can also
+     * be a Plugin class. In this case, its implementation will be directly
+     * returned if present.
+     * </p>
+     *
+     * @param facet the facet class
+     * @param <T>   the facet type
+     * @return the facet implementation or null if not present
+     * @throws java.lang.IllegalStateException if more than one implementation exists for the facet
+     */
+    <T> T getFacet(@Nullable Class<T> facet) throws IllegalStateException {
+        T plugin = null;
+        if (facet != null) {
+            List<T> plugins = getFacets(facet);
+            if (plugins.size() > 1) {
+                throw new IllegalStateException("One implementation was expected for the " + facet.getSimpleName() + " facet, but found: " + plugins.toString());
+            } else if (plugins.size() == 1) {
+                plugin = plugins.get(0);
+            }
+        }
+        return plugin;
+    }
+
+    /**
+     * Returns the list of plugins implementing the given facet.
+     * <p>
+     * In order to provide more flexibility, the given class can also
+     * be a Plugin class. In this case, its implementation will be directly
+     * returned if present.
+     * </p>
+     *
+     * @param facet the facet class
+     * @param <T>   the facet type
+     * @return the list of facet implementations, or an empty list if not present
+     */
+    <T> List<T> getFacets(@Nullable Class<T> facet) {
+        if (facet != null && Plugin.class.isAssignableFrom(facet)) {
+            List<T> ts = new ArrayList<T>();
+            Plugin plugin = plugins.get(facet);
+            if (plugin != null) {
+                //noinspection unchecked
+                ts.add((T) plugin);
+            }
+            return ts;
+        }
+        //noinspection unchecked
+        return (List<T>) facets.get(facet);
+    }
+
+    private boolean isFacet(Class<?> aClass) {
+        return aClass.isAnnotationPresent(Facet.class);
+    }
+}

--- a/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
@@ -761,6 +761,11 @@ public class InitContextInternal implements InitContext
     }
 
     @Override
+    public Map<String, String> kernelParams() {
+        return kernelParams;
+    }
+
+    @Override
     public String kernelParam(String key)
     {
         return kernelParams.get(key);

--- a/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
@@ -36,14 +36,7 @@ import io.nuun.kernel.core.internal.scanner.inmemory.InMemoryMultiThreadClasspat
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.net.URL;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -206,12 +199,9 @@ public class InitContextInternal implements InitContext
         }
         else if (classpathScanMode == ClasspathScanMode.IN_MEMORY)
         {
-
             Classpath classpath = InMemoryMultiThreadClasspath.INSTANCE;
             classpathScanner = classpathScannerFactory.createInMemory(classpath, packageRootArray);
-
         }
-
     }
 
     class IsModuleOverriding implements Predicate<Class<? extends Module>>
@@ -241,10 +231,6 @@ public class InitContextInternal implements InitContext
     class ModuleClass2Instance implements Function<Class<? extends Module>, UnitModule>
     {
 
-        /*
-         * (non-Javadoc)
-         * @see com.google.common.base.Function#apply(java.lang.Object)
-         */
         @Override
         public UnitModule apply(Class<? extends Module> classpathClass)
         {
@@ -316,13 +302,6 @@ public class InitContextInternal implements InitContext
             };
             classpathScanner.scanClasspathForSpecification(new DescendantOfSpecification(parentType), callback); // ok
         }
-
-        // for (Class<?> type : this.typesClassesToScan)
-        // {
-        // scanClasspathForSubType = this.classpathScanner.scanClasspathForTypeClass(type);
-        // // clässes.addAll(scanClasspathForSubType);
-        // this.mapTypes.put(type, scanClasspathForSubType);
-        // }
 
         for (final String typeName : parentTypesRegexToScan)
         {
@@ -719,16 +698,6 @@ public class InitContextInternal implements InitContext
         parentTypesRegexToBind.add(type);
     }
 
-    /**
-     * @category bind
-     * @param specification
-     */
-    // public void addSpecificationToBind(Specification<Class<?>> specification)
-    // {
-    // this.specificationsToBind.add(specification);
-    // this.mapSpecificationScope.put(specification, Scopes.NO_SCOPE);
-    // }
-
     private void updateScope(Key key, Object scope)
     {
         if (scope != null)
@@ -739,7 +708,6 @@ public class InitContextInternal implements InitContext
         {
             mapOfScopes.put(key, Scopes.NO_SCOPE);
         }
-
     }
 
     public void addSpecificationToBind(Specification<Class<?>> specification, Object scope)
@@ -792,18 +760,6 @@ public class InitContextInternal implements InitContext
         childOverridingModules.add(new ModuleEmbedded(module));
     }
 
-    // public void setContainerContext(Object containerContext)
-    // {
-    // this.containerContext = containerContext;
-    // }
-
-    // INTERFACE KERNEL PARAM USED BY PLUGIN IN INIT //
-
-    // public Object containerContext()
-    // {
-    // return this.containerContext;
-    // }
-
     @Override
     public String kernelParam(String key)
     {
@@ -849,6 +805,16 @@ public class InitContextInternal implements InitContext
     public Collection<? extends Plugin> dependentPlugins()
     {
         return Collections.emptySet();
+    }
+
+    @Override
+    public List<?> dependencies() {
+        return new ArrayList<Object>();
+    }
+
+    @Override
+    public <T> T dependency(Class<T> dependencyClass) {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
@@ -818,6 +818,11 @@ public class InitContextInternal implements InitContext
     }
 
     @Override
+    public <T> List<T> dependencies(Class<T> dependencyClass) {
+        return new ArrayList<T>();
+    }
+
+    @Override
     public <T> T dependency(Class<T> dependencyClass) {
         return null;
     }

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -38,8 +38,6 @@ import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.BindingRequest;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
-import io.nuun.kernel.api.plugin.request.KernelParamsRequestType;
 import io.nuun.kernel.core.KernelException;
 import io.nuun.kernel.spi.DependencyInjectionProvider;
 import org.slf4j.Logger;
@@ -63,15 +61,14 @@ public final class KernelCore implements Kernel
 {
 
     private static final int                               MAXIMAL_ROUND_NUMBER           = 50;
-    private static AtomicInteger                           kernelIndex = new AtomicInteger();
+    private static AtomicInteger                           kernelIndex                    = new AtomicInteger();
     private final Logger                                   logger;
     private final String                                   name;
 
     private static final String                           NUUN_PROPERTIES_PREFIX         = "nuun-";
-    private final PluginSortStrategy pluginSortStrategy = new PluginSortStrategy();
 
     private boolean                                        spiPluginEnabled               = true;
-    private Map<String, Plugin>                            plugins                        = Collections.synchronizedMap(new HashMap<String, Plugin>());
+    private PluginRegistry                                 pluginRegistry                        = new PluginRegistry();
     private Map<String, Plugin>                            pluginsToAdd                   = Collections.synchronizedMap(new HashMap<String, Plugin>());
 
     private final InitContextInternal                      initContext;
@@ -86,7 +83,7 @@ public final class KernelCore implements Kernel
 
     private Collection<DependencyInjectionProvider>        globalDependencyInjectionProviders;
     private Set<URL>                                       globalAdditionalClasspath;
-    private RoundInternal roundEnv;
+    private RoundInternal                                  round;
     private DependencyInjectionMode                        dependencyInjectionMode;
     private ClasspathScanMode                              classpathScanMode              = ClasspathScanMode.NOMINAL;
     private final List<ModuleValidation>                   globalModuleValidations        = Collections.synchronizedList(new ArrayList<ModuleValidation>());
@@ -127,39 +124,42 @@ public final class KernelCore implements Kernel
     @Override
     public synchronized void init()
     {
-        if (!initialized)
-        {
-            List<Plugin> fetchedPlugins = fetchPlugins(pluginsToAdd.values());
-            preparePlugins(fetchedPlugins);
-            extensionManager = new ExtensionManager(fetchedPlugins, Thread.currentThread().getContextClassLoader());
-            extensionManager.initializing();
-            initPlugins();
-            computeGlobalModuleProviders();
-            initialized = true;
-            extensionManager.initialized();
-        }
-        else
-        {
+        if (initialized) {
             throw new KernelException("Kernel is already initialized");
         }
+
+        pluginRegistry = fetchPlugins(pluginsToAdd.values());
+        FacetRegistry facetRegistry = new FacetRegistry(pluginRegistry.getPlugins());
+        DependencyProvider dependencyProvider = new DependencyProvider(pluginRegistry, facetRegistry);
+        preparePlugins(kernelParamsAndAlias);
+
+        extensionManager = new ExtensionManager(pluginRegistry.getPlugins(), Thread.currentThread().getContextClassLoader());
+        extensionManager.initializing();
+
+        initPlugins(pluginRegistry.getPlugins(), facetRegistry, dependencyProvider);
+        computeGlobalModuleProviders();
+
+        initialized = true;
+
+        extensionManager.initialized();
     }
 
-    public void preparePlugins(List<Plugin> fetchedPlugins) {
-        initRoundEnvironment(fetchedPlugins);
-        checkPlugins(fetchedPlugins);
-        computeAliases(fetchedPlugins);
+    public void preparePlugins(AliasMap kernelParams) {
+        initRoundEnvironment();
+        new PluginSpecification().isSatisfyBy(pluginRegistry, kernelParams);
+        computeAliases();
         fetchGlobalParametersFromPlugins();
     }
 
-    private void initRoundEnvironment(List<? extends Plugin> fetchedPlugins)
+    private void initRoundEnvironment()
     {
         // we initialize plugins
-        roundEnv = new RoundInternal();
+        round = new RoundInternal();
 
-        for (Plugin plugin : fetchedPlugins)
+        for (Plugin plugin : pluginRegistry.getPlugins())
         {
             // we pass the roundEnvironment
-            plugin.provideRound(roundEnv);
+            plugin.provideRound(round);
         }
     }
 
@@ -170,7 +170,7 @@ public final class KernelCore implements Kernel
 
         // Constants from plugin outside rounds
         // We pass the container context object for plugin
-        for (Plugin plugin : plugins.values())
+        for (Plugin plugin : pluginRegistry.getPlugins())
         {
             plugin.provideContainerContext(containerContext);
 
@@ -200,28 +200,28 @@ public final class KernelCore implements Kernel
         }
     }
 
-    private LinkedList<Plugin> fetchPlugins(Collection<? extends Plugin> pluginsToAdd)
+    private PluginRegistry fetchPlugins(Collection<? extends Plugin> pluginsToAdd)
     {
-        LinkedList<Plugin> fetchedPlugins = new LinkedList<Plugin>();
+        PluginRegistry pluginRegistry = new PluginRegistry();
         for (Plugin plugin : pluginsToAdd)
         {
-            fetchedPlugins.add(plugin);
+            pluginRegistry.add(plugin);
         }
 
         if (spiPluginEnabled)
         {
             for (Plugin plugin : ServiceLoader.load(Plugin.class, Thread.currentThread().getContextClassLoader()))
             {
-                fetchedPlugins.add(plugin);
+                pluginRegistry.add(plugin);
             }
         }
-        return fetchedPlugins;
+        return pluginRegistry;
     }
 
-    private AliasMap computeAliases(List<? extends Plugin> fetchedPlugins)
+    private AliasMap computeAliases()
     {
         // Compute alias
-        for (Plugin plugin : fetchedPlugins)
+        for (Plugin plugin : pluginRegistry.getPlugins())
         {
             Map<String, String> pluginKernelParametersAliases = plugin.kernelParametersAliases();
             for (Entry<String, String> entry : pluginKernelParametersAliases.entrySet())
@@ -242,84 +242,6 @@ public final class KernelCore implements Kernel
         }
 
         return kernelParamsAndAlias;
-    }
-
-    private void checkPlugins(List<Plugin> fetchedPlugins)
-    {
-        plugins.clear();
-
-        List<Class<? extends Plugin>> pluginClasses = new ArrayList<Class<? extends Plugin>>();
-
-        for (Plugin plugin : fetchedPlugins)
-        {
-            String pluginName = plugin.name();
-            if (Strings.isNullOrEmpty(pluginName))
-            {
-                throw new KernelException("Plugin %s doesn't have a correct name. It won't be installed.", pluginName);
-            }
-
-            Object ok = plugins.put(pluginName, plugin);
-            if (ok == null)
-            {
-                logger.debug("checking Plugin {}.", pluginName);
-                // Check for required parameter
-                // ============================
-                Collection<KernelParamsRequest> kernelParamsRequests = plugin.kernelParamsRequests();
-                Collection<String> computedMandatoryParams = new HashSet<String>();
-                for (KernelParamsRequest kernelParamsRequest : kernelParamsRequests)
-                {
-                    if (kernelParamsRequest.requestType == KernelParamsRequestType.MANDATORY)
-                    {
-                        computedMandatoryParams.add(kernelParamsRequest.keyRequested);
-                    }
-                }
-
-                if (kernelParamsAndAlias.containsAllKeys(computedMandatoryParams))
-                {
-                    pluginClasses.add(plugin.getClass());
-                }
-                else
-                {
-                    throw new KernelException("Plugin " + pluginName + " misses parameter/s : " + kernelParamsRequests.toString());
-                }
-
-            }
-            else
-            {
-                throw new KernelException("Can not have 2 Plugin %s of the same type %s. please fix this before the kernel can start.", pluginName, plugin
-                        .getClass().getName());
-            }
-        }
-
-        // Check for required and dependent plugins
-        for (Plugin plugin : plugins.values())
-        {
-            assertDependenciesArePresent(plugin, pluginClasses);
-        }
-    }
-
-    /**
-     * Verifies that the plugin dependencies are present in the plugin list.
-     * The list should contains both dependent and required plugins.
-     *
-     * @param plugin the plugin to check
-     * @param availablePlugins the list of available plugins
-     */
-    private void assertDependenciesArePresent(Plugin plugin, List<Class<? extends Plugin>> availablePlugins) {
-        Collection<Class<? extends Plugin>> requiredPlugins = plugin.requiredPlugins();
-
-        if (requiredPlugins != null && !requiredPlugins.isEmpty() && !availablePlugins.containsAll(requiredPlugins))
-        {
-            throw new KernelException("Plugin %s misses the following plugin/s as dependency/ies %s", plugin.name(), requiredPlugins.toString());
-        }
-
-
-        Collection<Class<? extends Plugin>> dependentPlugins = plugin.dependentPlugins();
-
-        if (dependentPlugins != null && !dependentPlugins.isEmpty() && !availablePlugins.containsAll(dependentPlugins))
-        {
-            throw new KernelException("Plugin %s misses the following plugin/s as dependee/s %s", plugin.name(), dependentPlugins.toString());
-        }
     }
 
     @Override
@@ -409,7 +331,7 @@ public final class KernelCore implements Kernel
     @Override
     public Map<String, Plugin> plugins()
     {
-        return this.plugins;
+        return this.pluginRegistry.getPluginsByName();
     }
 
     @Override
@@ -434,38 +356,36 @@ public final class KernelCore implements Kernel
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private void initPlugins()
+    private void initPlugins(Collection<Plugin> globalPlugins, FacetRegistry facetRegistry, DependencyProvider dependencyProvider)
     {
 
-        // We reset the resettable element of initcontext
+        // We reset the resettable elements of initContext
         initContext.reset();
 
         // Get plugins requests
         // ====================
-        Collection<Plugin> globalPlugins = plugins.values(); // first round all plugins
 
         // We sort them
         ArrayList<Plugin> unOrderedPlugins = new ArrayList<Plugin>(globalPlugins);
         logger.trace("unordered plugins: (" + unOrderedPlugins.size() + ") " + unOrderedPlugins);
-        orderedPlugins = pluginSortStrategy.sortPlugins(unOrderedPlugins);
+        orderedPlugins = new PluginSortStrategy(facetRegistry).sortPlugins(unOrderedPlugins);
         logger.trace("ordered plugins: (" + orderedPlugins.size() + ") " + orderedPlugins);
         Map<String, InitState> states = new HashMap<String, InitState>();
 
         ArrayList<Plugin> roundOrderedPlugins = new ArrayList<Plugin>(orderedPlugins);
 
 
+        logger.info("Initializing");
         do
         { // ROUND ITERATIONS
 
             // we update the number of initialization round.
-            initContext.roundNumber(roundEnv.number());
+            initContext.roundNumber(round.number());
 
-            logger.info("Initializing: round " + roundEnv.number());
+            logger.info("Round #" + round.number());
 
             for (Plugin plugin : roundOrderedPlugins)
             {
-
                 // Configure properties prefixes
                 String pluginPropertiesPrefix = plugin.pluginPropertiesPrefix();
                 if (!Strings.isNullOrEmpty(pluginPropertiesPrefix))
@@ -474,84 +394,11 @@ public final class KernelCore implements Kernel
                 }
 
                 // Configure package root
-                String pluginPackageRoot = plugin.pluginPackageRoot();
-                fillPackagesRoot(pluginPackageRoot);
+                fillPackagesRoot(plugin.pluginPackageRoot());
 
-                Collection<ClasspathScanRequest> classpathScanRequests = plugin.classpathScanRequests();
-                if (classpathScanRequests != null && classpathScanRequests.size() > 0)
-                {
-                    for (ClasspathScanRequest request : classpathScanRequests)
-                    {
-                        switch (request.requestType)
-                        {
-                            case ANNOTATION_TYPE:
-                                initContext.addAnnotationTypesToScan((Class<? extends Annotation>) request.objectRequested);
-                                break;
-                            case ANNOTATION_REGEX_MATCH:
-                                initContext.addAnnotationRegexesToScan((String) request.objectRequested);
-                                break;
-                            case SUBTYPE_OF_BY_CLASS:
-                                initContext.addParentTypeClassToScan((Class<?>) request.objectRequested);
-                                break;
-                            case SUBTYPE_OF_BY_TYPE_DEEP:
-                                initContext.addAncestorTypeClassToScan((Class<?>) request.objectRequested);
-                                break;
-                            case SUBTYPE_OF_BY_REGEX_MATCH:
-                                initContext.addParentTypeRegexesToScan((String) request.objectRequested);
-                                break;
-                            case RESOURCES_REGEX_MATCH:
-                                initContext.addResourcesRegexToScan((String) request.objectRequested);
-                                break;
-                            case TYPE_OF_BY_REGEX_MATCH:
-                                initContext.addTypeRegexesToScan((String) request.objectRequested);
-                                break;
-                            case VIA_SPECIFICATION:
-                                initContext.addSpecificationToScan(request.specification);
-                                break;
-                            default:
-                                logger.warn("{} is not a ClasspathScanRequestType a o_O", request.requestType);
-                                break;
-                        }
-                    }
-                }
+                registerClasspathScanRequests(plugin);
 
-                Collection<BindingRequest> bindingRequests = plugin.bindingRequests();
-                if (bindingRequests != null && bindingRequests.size() > 0)
-                {
-                    for (BindingRequest request : bindingRequests)
-                    {
-                        switch (request.requestType)
-                        {
-                            case ANNOTATION_TYPE:
-                                initContext.addAnnotationTypesToBind((Class<? extends Annotation>) request.requestedObject, request.requestedScope);
-                                break;
-                            case ANNOTATION_REGEX_MATCH:
-                                initContext.addAnnotationRegexesToBind((String) request.requestedObject, request.requestedScope);
-                                break;
-                            case META_ANNOTATION_TYPE:
-                                initContext.addMetaAnnotationTypesToBind((Class<? extends Annotation>) request.requestedObject, request.requestedScope);
-                                break;
-                            case META_ANNOTATION_REGEX_MATCH:
-                                initContext.addMetaAnnotationRegexesToBind((String) request.requestedObject, request.requestedScope);
-                                break;
-                            case SUBTYPE_OF_BY_CLASS:
-                                initContext.addParentTypeClassToBind((Class<?>) request.requestedObject, request.requestedScope);
-                                break;
-                            case SUBTYPE_OF_BY_TYPE_DEEP:
-                                initContext.addAncestorTypeClassToBind((Class<?>) request.requestedObject, request.requestedScope);
-                                break;
-                            case SUBTYPE_OF_BY_REGEX_MATCH:
-                                initContext.addTypeRegexesToBind((String) request.requestedObject, request.requestedScope);
-                                break;
-                            case VIA_SPECIFICATION:
-                                initContext.addSpecificationToBind(request.specification, request.requestedScope);
-                                break;
-                            default:
-                                logger.warn("{} is not a BindingRequestType o_O !", request.requestType);
-                                break;
-                        }
-                    }
-                }
+                registerBindingRequests(plugin);
             } // end plugin request
 
             for (URL url : globalAdditionalClasspath)
@@ -567,21 +414,12 @@ public final class KernelCore implements Kernel
             for (Plugin plugin : roundOrderedPlugins)
             {
                 InitContext actualInitContext = initContext;
-
-                // TODO : we compute dependencies only in round 0 for first version , no other plugin will be
-                // given
-                Collection<Class<? extends Plugin>> requiredPluginsClasses = plugin.requiredPlugins();
-                Collection<Class<? extends Plugin>> dependentPluginsClasses = plugin.dependentPlugins();
-                if (roundEnv.number() == 0 && requiredPluginsClasses != null && !requiredPluginsClasses.isEmpty() || dependentPluginsClasses != null
-                        && !dependentPluginsClasses.isEmpty())
+                if (round.isFirst())
                 {
-                    Collection<Plugin> requiredPlugins = filterPlugins(globalPlugins, requiredPluginsClasses);
-                    Collection<Plugin> dependentPlugins = filterPlugins(globalPlugins, dependentPluginsClasses);
-                    actualInitContext = proxyfy(initContext, requiredPlugins, dependentPlugins);
+                    actualInitContext = provideInitContextWithDependencies(plugin, dependencyProvider);
                 }
-
                 String name = plugin.name();
-                logger.info("Plugin {}.", name);
+                logger.info(" * {} plugin", name);
                 InitState state = plugin.init(actualInitContext);
                 states.put(name, state);
             }
@@ -601,7 +439,6 @@ public final class KernelCore implements Kernel
                     UnitModule unitModule = plugin.unitModule();
                     {
                         boolean override = false;
-
                         handleUnitModule(plugin, pluginName, unitModule, override);
                     }
 
@@ -609,15 +446,12 @@ public final class KernelCore implements Kernel
                     UnitModule overridingUnitModule = plugin.overridingUnitModule();
                     {
                         boolean override = true;
-
                         handleUnitModule(plugin, pluginName, overridingUnitModule, override);
-
                     }
 
                     if (unitModule == null && overridingUnitModule == null) {
                         logger.debug("For information Plugin {} does not provide any UnitModule via unitModule() nor overridingUnitModule().",  pluginName);
                     }
-
                 }
                 else
                 { // the plugin is not initialized we add it for a new round
@@ -627,12 +461,95 @@ public final class KernelCore implements Kernel
             }
             roundOrderedPlugins = nextRoundOrderedPlugins;
             // increment round number
-            roundEnv.next();
+            round.next();
         }
-        while (!roundOrderedPlugins.isEmpty() && roundEnv.number() < MAXIMAL_ROUND_NUMBER);
+        while (!roundOrderedPlugins.isEmpty() && round.number() < MAXIMAL_ROUND_NUMBER);
 
         // When all round are done.
 
+    }
+
+    private void registerBindingRequests(Plugin plugin) {
+        Collection<BindingRequest> bindingRequests = plugin.bindingRequests();
+        if (bindingRequests != null && bindingRequests.size() > 0)
+        {
+            for (BindingRequest request : bindingRequests)
+            {
+                switch (request.requestType)
+                {
+                    case ANNOTATION_TYPE:
+                        //noinspection unchecked
+                        initContext.addAnnotationTypesToBind((Class<? extends Annotation>) request.requestedObject, request.requestedScope);
+                        break;
+                    case ANNOTATION_REGEX_MATCH:
+                        initContext.addAnnotationRegexesToBind((String) request.requestedObject, request.requestedScope);
+                        break;
+                    case META_ANNOTATION_TYPE:
+                        //noinspection unchecked
+                        initContext.addMetaAnnotationTypesToBind((Class<? extends Annotation>) request.requestedObject, request.requestedScope);
+                        break;
+                    case META_ANNOTATION_REGEX_MATCH:
+                        initContext.addMetaAnnotationRegexesToBind((String) request.requestedObject, request.requestedScope);
+                        break;
+                    case SUBTYPE_OF_BY_CLASS:
+                        initContext.addParentTypeClassToBind((Class<?>) request.requestedObject, request.requestedScope);
+                        break;
+                    case SUBTYPE_OF_BY_TYPE_DEEP:
+                        initContext.addAncestorTypeClassToBind((Class<?>) request.requestedObject, request.requestedScope);
+                        break;
+                    case SUBTYPE_OF_BY_REGEX_MATCH:
+                        initContext.addTypeRegexesToBind((String) request.requestedObject, request.requestedScope);
+                        break;
+                    case VIA_SPECIFICATION:
+                        initContext.addSpecificationToBind(request.specification, request.requestedScope);
+                        break;
+                    default:
+                        logger.warn("{} is not a BindingRequestType o_O !", request.requestType);
+                        break;
+                }
+            }
+        }
+    }
+
+    private void registerClasspathScanRequests(Plugin plugin) {
+        Collection<ClasspathScanRequest> classpathScanRequests = plugin.classpathScanRequests();
+        if (classpathScanRequests != null && classpathScanRequests.size() > 0)
+        {
+            for (ClasspathScanRequest request : classpathScanRequests)
+            {
+                switch (request.requestType)
+                {
+                    case ANNOTATION_TYPE:
+                        //noinspection unchecked
+                        initContext.addAnnotationTypesToScan((Class<? extends Annotation>) request.objectRequested);
+                        break;
+                    case ANNOTATION_REGEX_MATCH:
+                        initContext.addAnnotationRegexesToScan((String) request.objectRequested);
+                        break;
+                    case SUBTYPE_OF_BY_CLASS:
+                        initContext.addParentTypeClassToScan((Class<?>) request.objectRequested);
+                        break;
+                    case SUBTYPE_OF_BY_TYPE_DEEP:
+                        initContext.addAncestorTypeClassToScan((Class<?>) request.objectRequested);
+                        break;
+                    case SUBTYPE_OF_BY_REGEX_MATCH:
+                        initContext.addParentTypeRegexesToScan((String) request.objectRequested);
+                        break;
+                    case RESOURCES_REGEX_MATCH:
+                        initContext.addResourcesRegexToScan((String) request.objectRequested);
+                        break;
+                    case TYPE_OF_BY_REGEX_MATCH:
+                        initContext.addTypeRegexesToScan((String) request.objectRequested);
+                        break;
+                    case VIA_SPECIFICATION:
+                        initContext.addSpecificationToScan(request.specification);
+                        break;
+                    default:
+                        logger.warn("{} is not a ClasspathScanRequestType a o_O", request.requestType);
+                        break;
+                }
+            }
+        }
     }
 
     private void handleUnitModule(Plugin plugin, String pluginName, UnitModule unitModule, boolean override)
@@ -739,34 +656,50 @@ public final class KernelCore implements Kernel
         return null;
     }
 
+    private InitContext provideInitContextWithDependencies(Plugin plugin, DependencyProvider dependencyProvider) {
+        InitContext actualInitContext = initContext;
+        // TODO : we compute dependencies only in round 0 for first version , no other plugin will be given
+        Collection<Class<?>> requiredPluginsClasses = plugin.requiredPlugins();
+        Collection<Class<?>> dependentPluginsClasses = plugin.dependentPlugins();
+        if (requiredPluginsClasses != null && !requiredPluginsClasses.isEmpty() || dependentPluginsClasses != null
+                && !dependentPluginsClasses.isEmpty())
+        {
+            actualInitContext = proxyfy(initContext, plugin.getClass(), dependencyProvider);
+        }
+        return actualInitContext;
+    }
+
     /**
      * Filters a collection of plugin instances according to a collection of plugin classes.
      *
-     * @param plugins the plugin instances
-     * @param requiredPlugins the required plugin classes
+     * @param dependencies the required plugin classes
+     * @param facetRegistry the facet registry
      * @return the filtered set of plugins
      */
-    private Set<Plugin> filterPlugins(Collection<Plugin> plugins, Collection<Class<? extends Plugin>> requiredPlugins)
+    private Set<Plugin> filterPlugins(Collection<Class<?>> dependencies, FacetRegistry facetRegistry)
     {
         Set<Plugin> filteredSet = new HashSet<Plugin>();
 
-        for (Plugin plugin : plugins)
-        {
-            if (requiredPlugins.contains(plugin.getClass()))
-            {
-                filteredSet.add(plugin);
+        for (Class<?> requiredPlugin : dependencies) {
+            if (Plugin.class.isAssignableFrom(requiredPlugin)) {
+                Plugin plugin = pluginRegistry.get((Class<? extends Plugin>) requiredPlugin);
+                if (plugin != null) {
+                    filteredSet.add(plugin);
+                }
+            } else {
+                filteredSet.addAll((Collection<? extends Plugin>) facetRegistry.getFacets(requiredPlugin));
             }
         }
 
         return filteredSet;
     }
 
-    private InitContext proxyfy(final InitContext initContext, final Collection<Plugin> requiredPlugins, final Collection<Plugin> dependentPlugins)
+    private InitContext proxyfy(final InitContext initContext, final Class<? extends Plugin> pluginClass, final DependencyProvider dependencyProvider)
     {
         return (InitContext) Proxy.newProxyInstance(
                 initContext.getClass().getClassLoader(),
                 new Class[] {
-                    InitContext.class
+                        InitContext.class
                 },
                 new InvocationHandler()
                 {
@@ -776,11 +709,20 @@ public final class KernelCore implements Kernel
                     {
                         if (method.getName().equals("pluginsRequired"))
                         {
-                            return requiredPlugins;
+                            return dependencyProvider.getRequired(pluginClass);
                         }
                         else if (method.getName().equals("dependentPlugins"))
                         {
-                            return dependentPlugins;
+                            return dependencyProvider.getDependent(pluginClass);
+                        }
+                        else if (method.getName().equals("dependencies"))
+                        {
+                            return dependencyProvider.getAll(pluginClass);
+                        }
+                        else if (method.getName().equals("dependency"))
+                        {
+                            Class<?> dependencyClass = (Class<?>) args[0];
+                            return dependencyProvider.getFacets(pluginClass, dependencyClass);
                         }
                         else
                         {

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
@@ -1,0 +1,94 @@
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.core.KernelException;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This registry holds all the plugin contained by the kernel.
+ * It validates the added plugins and provides accessor methods.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+class PluginRegistry {
+
+    public static final String NAME_UNIQUENESS_ERROR = "The kernel contains two plugins with the same name (%s): %s, %s";
+    public static final String TYPE_UNIQUENESS_ERROR = "The kernel contains two plugins of type ";
+    public static final String NAME_VALIDATION_ERROR = "The plugin %s doesn't have a correct name. It should not be null or empty.";
+
+    private final Map<Class<? extends Plugin>, Plugin> pluginsByClass = new HashMap<Class<? extends Plugin>, Plugin>();
+    private final Map<String, Plugin> pluginsByName = new HashMap<String, Plugin>();
+
+    /**
+     * Adds a plugin to the registry. It checks if the plugin name is valid
+     * and if the plugin name and type are unique.
+     *
+     * @param plugin the plugin to add
+     */
+    void add(Plugin plugin) {
+        assertNameNotBlank(plugin);
+
+        Plugin previous = this.pluginsByClass.put(plugin.getClass(), plugin);
+        if (previous != null) {
+            throw new KernelException(TYPE_UNIQUENESS_ERROR + plugin.getClass().getCanonicalName());
+        }
+
+        Plugin previousPlugin = this.pluginsByName.put(plugin.name(), plugin);
+        if (previousPlugin != null) {
+            throw new KernelException(String.format(NAME_UNIQUENESS_ERROR, plugin.name(),
+                    plugin.getClass().getCanonicalName(), previousPlugin.getClass().getCanonicalName()));
+        }
+    }
+
+    private void assertNameNotBlank(Plugin plugin) {
+        String name = plugin.name();
+        if (name == null || name.equals("")) {
+            throw new KernelException(NAME_VALIDATION_ERROR, plugin.getClass().getCanonicalName());
+        }
+    }
+
+    /**
+     * Returns the plugin instance corresponding to the given class.
+     *
+     * @param pluginClass the plugin class
+     * @return the plugin instance
+     */
+    Plugin get(Class<? extends Plugin> pluginClass) {
+        return pluginsByClass.get(pluginClass);
+    }
+
+    /**
+     * Returns the plugin instance corresponding to the given name.
+     *
+     * @param name the plugin name
+     * @return the plugin instance
+     */
+    Plugin get(String name) {
+        return pluginsByName.get(name);
+    }
+
+    /**
+     * Returns all the plugin instances.
+     *
+     * @return the plugin instances
+     */
+    Collection<Plugin> getPlugins() {
+        return pluginsByClass.values();
+    }
+
+    /**
+     * Returns all the plugin classes.
+     *
+     * @return the plugin classes
+     */
+    Collection<Class<? extends Plugin>> getPluginClasses() {
+        return pluginsByClass.keySet();
+    }
+
+    public Map<String, Plugin> getPluginsByName() {
+        return pluginsByName;
+    }
+}

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
@@ -9,56 +9,88 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * The class provides a strategy for sorting plugins regarding their dependencies.
+ */
 class PluginSortStrategy {
+
+    private final FacetRegistry facetRegistry;
+
+    public PluginSortStrategy(FacetRegistry facetRegistry) {
+        this.facetRegistry = facetRegistry;
+    }
 
     public List<Plugin> sortPlugins(List<Plugin> unsortedPlugins) {
         Graph graph = new Graph(unsortedPlugins.size());
-        ArrayList<Plugin> sorted = new ArrayList<Plugin>();
-        Map<Integer, Plugin> idxPlug = new HashMap<Integer, Plugin>();
-        Map<Character, Plugin> charPlug = new HashMap<Character, Plugin>();
-        Map<Plugin, Integer> plugIdx = new HashMap<Plugin, Integer>();
-        Map<Class<? extends Plugin>, Integer> classPlugIdx = new HashMap<Class<? extends Plugin>, Integer>();
+        Vertices vertices = new Vertices();
 
         // Add vertices
         for (short i = 0; i < unsortedPlugins.size(); i++) {
-            char c = (char) i;
-            Plugin unsortedPlugin = unsortedPlugins.get(i);
-            Integer pluginIndex = graph.addVertex(c);
-
-            charPlug.put(c, unsortedPlugin);
-            idxPlug.put(pluginIndex, unsortedPlugin);
-            plugIdx.put(unsortedPlugin, pluginIndex);
-            classPlugIdx.put(unsortedPlugin.getClass(), pluginIndex);
+            char label = (char) i;
+            vertices.addVertex(label, graph.addVertex(label), unsortedPlugins.get(i));
         }
 
         // add edges
-        for (Map.Entry<Integer, Plugin> entry : idxPlug.entrySet()) {
-            Plugin source = entry.getValue();
+        for (Plugin source : unsortedPlugins) {
             // based on required plugins
-            for (Class<? extends Plugin> dependencyClass : source.requiredPlugins()) {
-                int start = classPlugIdx.get(dependencyClass);
-                int end = plugIdx.get(source);
-                graph.addEdge(start, end);
+            for (Class<?> requiredClass : source.requiredPlugins()) {
+                for (Class<?> dependencyClass : getCompleteDependencies(requiredClass)) {
+                    graph.addEdge(vertices.getIndex(dependencyClass), vertices.getIndex(source.getClass()));
+                }
             }
             // based on dependent plugins
-            for (Class<? extends Plugin> dependencyClass : source.dependentPlugins()) {
-                int start = plugIdx.get(source); // we inversed
-                int end = classPlugIdx.get(dependencyClass);
-                graph.addEdge(start, end);
+            for (Class<?> dependentClass : source.dependentPlugins()) {
+                for (Class<?> dependencyClass : getCompleteDependencies(dependentClass)) {
+                    graph.addEdge(vertices.getIndex(source.getClass()), vertices.getIndex(dependencyClass)); // we inverse
+                }
             }
         }
 
         // launch the algo
         char[] topologicalSort = graph.topologicalSort();
-
-        if (topologicalSort != null) {
-            for (Character c : topologicalSort) {
-                sorted.add(charPlug.get(c));
-            }
-        } else {
+        if (topologicalSort == null) {
             throw new KernelException("Error when sorting plugins: either a Cycle in dependencies or another cause.");
         }
 
+        ArrayList<Plugin> sorted = new ArrayList<Plugin>();
+        for (Character label : topologicalSort) {
+            sorted.add(vertices.getPlugin(label));
+        }
+
         return sorted;
+    }
+
+    private List<Class<?>> getCompleteDependencies(Class<?> declaredDependency) {
+        final List<Class<?>> dependencies = new ArrayList<Class<?>>();
+        if (!Plugin.class.isAssignableFrom(declaredDependency)) {
+            List<?> facets = facetRegistry.getFacets(declaredDependency);
+            // TODO remove the need for this loop. Add a getFacetClasses in the FacetRegistry.
+            for (Object facet : facets) {
+                dependencies.add(facet.getClass());
+            }
+        } else {
+            dependencies.add(declaredDependency);
+        }
+        return dependencies;
+    }
+
+    private static class Vertices {
+        Map<Integer, Plugin> pluginsByIndex = new HashMap<Integer, Plugin>();
+        Map<Character, Plugin> pluginsByLabel = new HashMap<Character, Plugin>();
+        Map<Class<?>, Integer> indexByPluginClasses = new HashMap<Class<?>, Integer>();
+
+        public void addVertex(char label, int index, Plugin plugin) {
+            pluginsByLabel.put(label, plugin);
+            pluginsByIndex.put(index, plugin);
+            indexByPluginClasses.put(plugin.getClass(), index);
+        }
+
+        public int getIndex(Class<?> pluginClass) {
+            return indexByPluginClasses.get(pluginClass);
+        }
+
+        public Plugin getPlugin(char label) {
+            return pluginsByLabel.get(label);
+        }
     }
 }

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginSpecification.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginSpecification.java
@@ -1,0 +1,60 @@
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
+import io.nuun.kernel.api.plugin.request.KernelParamsRequestType;
+import io.nuun.kernel.core.KernelException;
+
+import java.util.*;
+
+class PluginSpecification {
+
+    PluginRegistry isSatisfyBy(final PluginRegistry pluginRegistry, final AliasMap kernelParams) {
+        // Check mandatory params
+        for (Plugin plugin : pluginRegistry.getPlugins()) {
+            checkMandatoryParams(plugin, kernelParams);
+        }
+
+        // Check for required and dependent plugins
+        for (Plugin plugin : pluginRegistry.getPlugins()) {
+            assertDependenciesArePresent(plugin, pluginRegistry.getPluginClasses());
+        }
+        return pluginRegistry;
+    }
+
+    private void checkMandatoryParams(Plugin plugin, AliasMap kernelParams) {
+        Collection<KernelParamsRequest> kernelParamsRequests = plugin.kernelParamsRequests();
+        Collection<String> computedMandatoryParams = new HashSet<String>();
+
+        for (KernelParamsRequest kernelParamsRequest : kernelParamsRequests) {
+            if (kernelParamsRequest.requestType == KernelParamsRequestType.MANDATORY) {
+                computedMandatoryParams.add(kernelParamsRequest.keyRequested);
+            }
+        }
+
+        if (!kernelParams.containsAllKeys(computedMandatoryParams)) {
+            throw new KernelException("Plugin " + plugin.name() + " misses parameter/s : " + kernelParamsRequests.toString());
+        }
+    }
+
+    /**
+     * Verifies that the plugin dependencies are present in the plugin list.
+     * The list should contains both dependent and required plugins.
+     *
+     * @param plugin           the plugin to check
+     * @param availablePlugins the list of available plugins
+     */
+    private void assertDependenciesArePresent(Plugin plugin, Collection<Class<? extends Plugin>> availablePlugins) {
+        Collection<Class<?>> requiredPlugins = plugin.requiredPlugins();
+
+        if (requiredPlugins != null && !requiredPlugins.isEmpty() && !availablePlugins.containsAll(requiredPlugins)) {
+            throw new KernelException("Plugin %s misses the following plugin/s as dependency/ies %s", plugin.name(), requiredPlugins.toString());
+        }
+
+        Collection<Class<?>> dependentPlugins = plugin.dependentPlugins();
+
+        if (dependentPlugins != null && !dependentPlugins.isEmpty() && !availablePlugins.containsAll(dependentPlugins)) {
+            throw new KernelException("Plugin %s misses the following plugin/s as dependee/s %s", plugin.name(), dependentPlugins.toString());
+        }
+    }
+}

--- a/core/src/main/java/io/nuun/kernel/core/internal/graph/Graph.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/graph/Graph.java
@@ -16,15 +16,8 @@
  */
 package io.nuun.kernel.core.internal.graph;
 
-
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class Graph {
 
-	Logger logger = LoggerFactory.getLogger(Graph.class);
-	
 	private final int MAX_VERTS;
 
 	private Vertex vertexList[]; // list of vertices
@@ -35,8 +28,8 @@ public class Graph {
 
 	private char sortedArray[];
 
-	public Graph(int maxvert) {
-		MAX_VERTS =maxvert;
+	public Graph(int maximumVertices) {
+		MAX_VERTS = maximumVertices;
 		vertexList = new Vertex[MAX_VERTS];
 		matrix = new int[MAX_VERTS][MAX_VERTS];
 		numVerts = 0;
@@ -45,7 +38,7 @@ public class Graph {
 				matrix[i][k] = 0;
 			}
 		}
-		sortedArray = new char[MAX_VERTS]; // sorted vert labels
+		sortedArray = new char[MAX_VERTS]; // sorted vertex labels
 	}
 
 	public int addVertex(char lab) {
@@ -54,8 +47,7 @@ public class Graph {
 	}
 
 	/**
-	 * 
-	 * end depends on start
+	 * Adds an edge where {@code end} depends on {@code start}
 	 * 
 	 * @param start dependee
 	 * @param end dependent
@@ -76,7 +68,6 @@ public class Graph {
 			int currentVertex = noSuccessors();
 			if (currentVertex == -1) // must be a cycle
 			{
-				System.out.println("ERROR: Graph has cycles");
 				return null;
 			}
 			// insert vertex label in sorted array (start at end)
@@ -85,10 +76,6 @@ public class Graph {
 			deleteVertex(currentVertex); // delete vertex
 		}
 
-		// vertices all gone; display sortedArray
-//		logger.debug("Topologically sorted order: ");
-//		for (int j = 0; j < orig_nVerts; j++)
-//			logger.debug("" + sortedArray[j]);
 		return sortedArray;
 	}
 
@@ -113,8 +100,7 @@ public class Graph {
 	}
 
 	public void deleteVertex(int delVert) {
-		if (delVert != numVerts - 1) // if not last vertex, delete from
-										// vertexList
+		if (delVert != numVerts - 1) // if not last vertex, delete from vertexList
 		{
 			for (int j = delVert; j < numVerts - 1; j++) {
 				vertexList[j] = vertexList[j + 1];

--- a/core/src/main/java/io/nuun/kernel/core/internal/graph/Vertex.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/graph/Vertex.java
@@ -18,7 +18,7 @@ package io.nuun.kernel.core.internal.graph;
 
 public class Vertex {
 	
-	public char label;
+	public final char label;
 
 	public Vertex(char lab) {
 		label = lab;

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
@@ -16,39 +16,28 @@
  */
 package io.nuun.kernel.core.internal.scanner.disk;
 
-import static org.reflections.util.FilterBuilder.prefix;
-
-import io.nuun.kernel.core.internal.utils.AssertUtils;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import io.nuun.kernel.core.internal.scanner.AbstractClasspathScanner;
-
-import java.lang.annotation.Annotation;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
-
+import io.nuun.kernel.core.internal.utils.AssertUtils;
 import org.kametic.specifications.Specification;
 import org.reflections.ReflectionUtils;
 import org.reflections.Reflections;
 import org.reflections.Store;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.*;
 import org.reflections.scanners.Scanner;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.scanners.TypeElementsScanner;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.reflections.util.FilterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
+import java.lang.annotation.Annotation;
+import java.net.URL;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static org.reflections.util.FilterBuilder.prefix;
 
 public class ClasspathScannerDisk extends AbstractClasspathScanner
 {
@@ -547,7 +536,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
 
     private <T> Collection<Class<? extends T>> toClasses(Collection<String> names)
     {
-        return ReflectionUtils.<T> forNames(names, new ClassLoader[]{ this.getClass().getClassLoader() });
+        return ReflectionUtils.forNames(names, new ClassLoader[]{ this.getClass().getClassLoader() });
     }
 
     private TypeElementsScanner buildTypeElementsScanner()

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
@@ -53,8 +53,7 @@ public class KernelSuite6Test
         catch (KernelException ke)
         {
             assertThat(ke.getMessage())
-                    .isEqualTo(
-                            "Plugin dummy-plugin-6-B misses the following plugin/s as dependee/s [class io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_D, class io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_C]");
+                    .isEqualTo("Plugin dummy-plugin-6-B misses the following dependency: io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_C");
         }
     }
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
@@ -1,0 +1,157 @@
+package io.nuun.kernel.core.internal;
+
+import com.google.common.collect.Lists;
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.api.annotations.Facet;
+import io.nuun.kernel.core.AbstractPlugin;
+import io.nuun.kernel.core.KernelException;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class DependencyProviderTest {
+
+    @Facet
+    private static interface Facet1 {}
+
+    @Facet
+    private static interface Facet2 {}
+
+    private static class RequiredPlugin1 extends AbstractPlugin implements Facet1 {
+        @Override
+        public String name() {
+            return "required-plugin1";
+        }
+    }
+    private static class RequiredPlugin2 extends AbstractPlugin implements Facet1 {
+        @Override
+        public String name() {
+            return "required-plugin2";
+        }
+    }
+
+    private static class DependentPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "dependent-plugin";
+        }
+    }
+
+    private static class WithDepsPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "with-deps-plugin";
+        }
+
+        @Override
+        public Collection<Class<?>> requiredPlugins() {
+            return Lists.<Class<?>>newArrayList(Facet1.class, Facet2.class);
+        }
+        @Override
+        public Collection<Class<?>> dependentPlugins() {
+            return Lists.<Class<?>>newArrayList(DependentPlugin.class);
+        }
+    }
+
+    private static class NoDepsPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "no-deps-plugin";
+        }
+    }
+
+    private DependencyProvider underTest;
+    private WithDepsPlugin withDepsPlugin;
+    private RequiredPlugin1 requiredPlugin1;
+    private RequiredPlugin2 requiredPlugin2;
+    private DependentPlugin dependentPlugin;
+
+    @Before
+    public void setup() {
+        FacetRegistry facetRegistry = Mockito.mock(FacetRegistry.class);
+
+        List<Facet1> requiredPlugins = new ArrayList<Facet1>();
+        requiredPlugin1 = new RequiredPlugin1();
+        requiredPlugin2 = new RequiredPlugin2();
+        requiredPlugins.add(requiredPlugin1);
+        requiredPlugins.add(requiredPlugin2);
+
+        List<DependentPlugin> dependentPlugins = new ArrayList<DependentPlugin>();
+        dependentPlugin = new DependentPlugin();
+        dependentPlugins.add(dependentPlugin);
+
+        Mockito.when(facetRegistry.getFacets(Facet1.class)).thenReturn(requiredPlugins);
+        Mockito.when(facetRegistry.getFacets(DependentPlugin.class)).thenReturn(dependentPlugins);
+
+        PluginRegistry pluginRegistry = Mockito.mock(PluginRegistry.class);
+        withDepsPlugin = new WithDepsPlugin();
+        Mockito.when(pluginRegistry.get(WithDepsPlugin.class)).thenReturn(withDepsPlugin);
+        Mockito.when(pluginRegistry.get(NoDepsPlugin.class)).thenReturn(new NoDepsPlugin());
+
+        underTest = new DependencyProvider(pluginRegistry, facetRegistry);
+
+    }
+
+    @Test
+    public void test_provide_dependencies_never_null() {
+        List<Plugin> dependencies = underTest.getRequired(NoDepsPlugin.class);
+        Assertions.assertThat(dependencies).isNotNull();
+    }
+
+    @Test
+    public void test_provide_required_dependencies() {
+        List<Plugin> dependencies = underTest.getRequired(WithDepsPlugin.class);
+
+        Assertions.assertThat(dependencies).hasSize(2);
+        Assertions.assertThat(dependencies).containsOnly(requiredPlugin1, requiredPlugin2);
+    }
+
+    @Test
+    public void test_provide_missing_dependent_dependencies() {
+        List<Plugin> dependencies = underTest.getDependent(NoDepsPlugin.class);
+        Assertions.assertThat(dependencies).isNotNull();
+    }
+
+    @Test
+    public void test_provide_dependent_dependencies() {
+        List<Plugin> dependencies = underTest.getDependent(WithDepsPlugin.class);
+
+        Assertions.assertThat(dependencies).hasSize(1);
+        Assertions.assertThat(dependencies).containsOnly(dependentPlugin);
+    }
+
+    @Test
+    public void test_provide_all_dependencies() {
+        List<Plugin> dependencies = underTest.getAll(WithDepsPlugin.class);
+
+        Assertions.assertThat(dependencies).hasSize(3);
+        Assertions.assertThat(dependencies).containsOnly(requiredPlugin1, requiredPlugin2, dependentPlugin);
+    }
+
+    @Test
+    public void test_provide_facet_dependencies_never_return_null() {
+        List<Facet2> dependencies = underTest.getFacets(WithDepsPlugin.class, Facet2.class);
+        Assertions.assertThat(dependencies).isNotNull();
+    }
+
+    @Test(expected = KernelException.class)
+    public void test_provide_facet_not_required_dependency() {
+        underTest.getFacets(NoDepsPlugin.class, Facet1.class);
+    }
+
+    @Test
+    public void test_provide_facet_dependencies() {
+        List<Facet1> dependencies = underTest.getFacets(WithDepsPlugin.class, Facet1.class);
+
+        Assertions.assertThat(dependencies).hasSize(2);
+        Assertions.assertThat(dependencies).containsOnly(requiredPlugin1, requiredPlugin2);
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
@@ -1,0 +1,161 @@
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.api.annotations.Facet;
+import io.nuun.kernel.core.AbstractPlugin;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests the facet registry.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class FacetRegistryTest {
+
+    @Facet
+    private static interface Facet1 {
+    }
+
+    private static class OneFacetPlugin extends AbstractPlugin implements Facet1 {
+        @Override
+        public String name() {
+            return "plugin-with-trait";
+        }
+    }
+
+    @Facet
+    private static interface Facet2 {
+    }
+
+    private static class TwoFacetPlugin extends AbstractPlugin implements Facet1, Facet2 {
+        @Override
+        public String name() {
+            return "plugin-with-trait2";
+        }
+    }
+
+    @Test
+    public void scanner_support_null_plugin_list() {
+        FacetRegistry registry = new FacetRegistry(null);
+        Assertions.assertThat(registry.getFacet(null)).isNull();
+    }
+
+    @Test
+    public void get_null_is_accepted() {
+        FacetRegistry registry = new FacetRegistry(new ArrayList<Plugin>());
+        Assertions.assertThat(registry.getFacet(null)).isNull();
+    }
+
+    @Test
+    public void scan_a_plugin_facet() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
+        plugins.add(oneFacetPlugin);
+
+        Facet1 facet1 = new FacetRegistry(plugins).getFacet(Facet1.class);
+
+        Assertions.assertThat(facet1).isNotNull();
+        Assertions.assertThat(facet1).isEqualTo(oneFacetPlugin);
+    }
+
+    @Test
+    public void scan_multiple_facet_in_a_plugin() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
+        plugins.add(twoFacetPlugin);
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        Facet1 facet1 = registry.getFacet(Facet1.class);
+        Facet2 facet2 = registry.getFacet(Facet2.class);
+
+        Assertions.assertThat(facet1).isNotNull();
+        Assertions.assertThat(facet1).isEqualTo(twoFacetPlugin);
+        Assertions.assertThat(facet2).isNotNull();
+        Assertions.assertThat(facet2).isEqualTo(twoFacetPlugin);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getFacet_fails_for_multiple_facet_implementation() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
+        TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
+        plugins.add(oneFacetPlugin);
+        plugins.add(twoFacetPlugin);
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        registry.getFacet(Facet1.class);
+    }
+
+    @Test
+    public void getFacets_never_return_null() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
+        plugins.add(oneFacetPlugin);
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        List<Facet2> facet2s = registry.getFacets(Facet2.class);
+
+        Assertions.assertThat(facet2s).isNotNull();
+        Assertions.assertThat(facet2s).isEmpty();
+    }
+
+    @Test
+    public void get_multiple_facet_implementations() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
+        TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
+        plugins.add(oneFacetPlugin);
+        plugins.add(twoFacetPlugin);
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        List<Facet1> facet1s = registry.getFacets(Facet1.class);
+
+        Assertions.assertThat(facet1s).hasSize(2);
+
+        Assertions.assertThat(facet1s.get(0)).isEqualTo(oneFacetPlugin);
+        Assertions.assertThat(facet1s.get(0)).isInstanceOf(OneFacetPlugin.class);
+
+        Assertions.assertThat(facet1s.get(1)).isEqualTo(twoFacetPlugin);
+        Assertions.assertThat(facet1s.get(1)).isInstanceOf(TwoFacetPlugin.class);
+
+
+        List<Facet2> facet2s = registry.getFacets(Facet2.class);
+        Assertions.assertThat(facet2s).hasSize(1);
+    }
+
+    private static class LegacyPlugin extends AbstractPlugin {
+        @Override
+        public String name() {
+            return "legacy-plugin";
+        }
+    }
+
+    @Test
+    public void get_plugin_implementation() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+        LegacyPlugin legacyPlugin = new LegacyPlugin();
+        plugins.add(legacyPlugin);
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        List<LegacyPlugin> legacyPlugins = registry.getFacets(LegacyPlugin.class);
+
+        Assertions.assertThat(legacyPlugins).hasSize(1);
+
+        Assertions.assertThat(legacyPlugins.get(0)).isEqualTo(legacyPlugin);
+        Assertions.assertThat(legacyPlugins.get(0)).isInstanceOf(LegacyPlugin.class);
+    }
+
+    @Test
+    public void get_missing_plugin_implementations() {
+        List<Plugin> plugins = new ArrayList<Plugin>();
+
+        FacetRegistry registry = new FacetRegistry(plugins);
+        List<LegacyPlugin> legacyPlugins = registry.getFacets(LegacyPlugin.class);
+
+        Assertions.assertThat(legacyPlugins).hasSize(0);
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
@@ -19,6 +19,7 @@
  */
 package io.nuun.kernel.core.internal;
 
+import com.google.common.collect.Lists;
 import com.google.inject.*;
 import com.google.inject.matcher.Matchers;
 import io.nuun.kernel.api.Plugin;
@@ -314,11 +315,9 @@ public class KernelCoreIT
 
     
     static abstract class AbstractTestPlugin extends AbstractPlugin{
-    	public Collection<Class<? extends Plugin>> dep(Class<? extends Plugin> klazz)
+    	public Collection<Class<?>> dep(Class<?> klazz)
     	{
-    		Collection<Class<? extends Plugin>> plugins = new ArrayList<Class<? extends Plugin>>();
-            plugins.add(klazz);
-            return plugins;
+            return Lists.<Class<?>>newArrayList(klazz);
     	}
     }
     
@@ -332,7 +331,7 @@ public class KernelCoreIT
     	@Override
 		public String name() {return this.getClass().getName(); }
     	@Override
-		public Collection<Class<? extends Plugin>> requiredPlugins() {return dep(p13.class); }
+		public Collection<Class<?>> requiredPlugins() {return dep(p13.class); }
     }
     static class p3 extends AbstractTestPlugin
     {
@@ -359,7 +358,7 @@ public class KernelCoreIT
     	@Override
 		public String name() {return this.getClass().getName(); }
     	@Override
-		public Collection<Class<? extends Plugin>> requiredPlugins() {return dep(p11.class); }
+		public Collection<Class<?>> requiredPlugins() {return dep(p11.class); }
     }
     static class p8 extends AbstractTestPlugin
     {
@@ -386,14 +385,14 @@ public class KernelCoreIT
     	@Override
 		public String name() {return this.getClass().getName(); }
     	@Override
-		public Collection<Class<? extends Plugin>> requiredPlugins() {return dep(p6.class); }
+		public Collection<Class<?>> requiredPlugins() {return dep(p6.class); }
     }
     static class p13 extends AbstractTestPlugin
     {
     	@Override
 		public String name() {return this.getClass().getName(); }
     	@Override
-		public Collection<Class<? extends Plugin>> requiredPlugins() {return dep(p11.class); }
+		public Collection<Class<?>> requiredPlugins() {return dep(p11.class); }
     }
     
     @Test

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
@@ -85,7 +85,6 @@ public class KernelCoreIT
         }
         catch (KernelException ke)
         {
-            assertThat(ke.getMessage()).isEqualTo("Plugin dummyPlugin misses the following plugin/s as dependency/ies [class io.nuun.kernel.core.pluginsit.dummy23.DummyPlugin2]");
             underTest.addPlugin(DummyPlugin2.class);
             try {
                 underTest.init();
@@ -93,7 +92,6 @@ public class KernelCoreIT
             }
             catch (KernelException ke2)
             {
-                assertThat(ke2.getMessage()).isEqualTo("Plugin dummyPlugin2 misses the following plugin/s as dependency/ies [class io.nuun.kernel.core.pluginsit.dummy23.DummyPlugin3]");
                 underTest.addPlugin(DummyPlugin3.class);
                 underTest.addPlugin(plugin4);
                 underTest.addPlugin(DummyPlugin5.class);

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
@@ -1,0 +1,140 @@
+package io.nuun.kernel.core.internal;
+
+import io.nuun.kernel.api.Plugin;
+import io.nuun.kernel.core.AbstractPlugin;
+import io.nuun.kernel.core.KernelException;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.Collection;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class PluginRegistryTest {
+
+    private static class MyPlugin extends AbstractPlugin {
+
+        public static final String NAME = "my-plugin";
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+    }
+
+    private static class MyPlugin2 extends AbstractPlugin {
+
+        public static final String NAME = "my-plugin2";
+
+        @Override
+        public String name() {
+            return NAME;
+        }
+    }
+
+    private PluginRegistry underTest = new PluginRegistry();
+
+    @Test
+    public void test_get_by_class() {
+        Plugin plugin = new MyPlugin();
+        Plugin plugin2 = new MyPlugin2();
+
+        underTest.add(plugin);
+        underTest.add(plugin2);
+
+        Plugin myPlugin = underTest.get(MyPlugin.class);
+        Assertions.assertThat(myPlugin).isNotNull();
+        Assertions.assertThat(myPlugin).isEqualTo(plugin);
+
+        Plugin myPlugin2 = underTest.get(MyPlugin2.class);
+        Assertions.assertThat(myPlugin2).isNotNull();
+        Assertions.assertThat(myPlugin2).isEqualTo(plugin2);
+    }
+
+    @Test
+    public void test_get_by_name() {
+        Plugin plugin = new MyPlugin();
+        Plugin plugin2 = new MyPlugin2();
+
+        underTest.add(plugin);
+        underTest.add(plugin2);
+
+        Plugin myPlugin = underTest.get(MyPlugin.NAME);
+        Assertions.assertThat(myPlugin).isNotNull();
+        Assertions.assertThat(myPlugin).isEqualTo(plugin);
+
+        Plugin myPlugin2 = underTest.get(MyPlugin2.NAME);
+        Assertions.assertThat(myPlugin2).isNotNull();
+        Assertions.assertThat(myPlugin2).isEqualTo(plugin2);
+    }
+
+    @Test
+    public void test_get_plugins_cant_be_null() {
+        Assertions.assertThat(underTest.getPlugins()).isNotNull();
+    }
+
+    @Test
+    public void test_get_plugins() {
+        Plugin plugin = new MyPlugin();
+        Plugin plugin2 = new MyPlugin2();
+        underTest.add(plugin);
+        underTest.add(plugin2);
+
+        Collection<Plugin> plugins = underTest.getPlugins();
+        Assertions.assertThat(plugins).containsOnly(plugin, plugin2);
+    }
+
+    @Test
+    public void test_get_pluginClasses_cant_be_null() {
+        Assertions.assertThat(underTest.getPluginClasses()).isNotNull();
+    }
+
+    @Test
+    public void test_get_plugin_classes() {
+        Plugin plugin = new MyPlugin();
+        Plugin plugin2 = new MyPlugin2();
+        underTest.add(plugin);
+        underTest.add(plugin2);
+
+        Collection<Class<? extends Plugin>> plugins = underTest.getPluginClasses();
+        //noinspection unchecked
+        Assertions.assertThat(plugins).containsOnly(MyPlugin.class, MyPlugin2.class);
+    }
+
+    private static class UnnamedPlugin extends AbstractPlugin {
+
+        private String name;
+
+        public UnnamedPlugin(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+    }
+
+    @Test(expected = KernelException.class)
+    public void test_assertNameNotBlank_with_null() {
+        underTest.add(new UnnamedPlugin(null));
+    }
+
+    @Test(expected = KernelException.class)
+    public void test_assertNameNotBlank_with_empty() {
+        underTest.add(new UnnamedPlugin(""));
+    }
+
+    @Test(expected = KernelException.class)
+    public void test_assertUniqueness_with_class_conflict() {
+        underTest.add(new MyPlugin());
+        underTest.add(new MyPlugin());
+    }
+
+    @Test(expected = KernelException.class)
+    public void test_assertUniqueness_with_name_conflict() {
+        underTest.add(new MyPlugin());
+        underTest.add(new UnnamedPlugin(MyPlugin.NAME));
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
@@ -1,38 +1,99 @@
 package io.nuun.kernel.core.internal;
 
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.Plugin;
-import io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_B;
-import io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_C;
-import io.nuun.kernel.core.pluginsit.dummy6.DummyPlugin6_D;
+import io.nuun.kernel.api.annotations.Facet;
+import io.nuun.kernel.core.AbstractPlugin;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
+ * Tests the plugin sort according to their dependencies.
+ *
  * @author Pierre Thirouin
  */
 public class PluginSortStrategyTest {
 
-    private PluginSortStrategy strategy = new PluginSortStrategy();
-
     @Test
-    public void testSort() {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+    public void test_sort_plugins_with_dependencies() {
+        Plugin1 plugin1 = new Plugin1(); // declare P2 as dependent
+        Plugin2 plugin2 = new Plugin2();
+        Plugin3 plugin3 = new Plugin3(); // declare P2 as required and declare P4 as dependent
+        Plugin4 plugin4 = new Plugin4();
 
-        DummyPlugin6_C c = new DummyPlugin6_C();
-        plugins.add(c);
-        DummyPlugin6_D d = new DummyPlugin6_D();
-        plugins.add(d);
-        DummyPlugin6_B b = new DummyPlugin6_B();  // <--- C ,  D
-        plugins.add(b);
-
+        List<Plugin> plugins = Lists.<Plugin>newArrayList(plugin4, plugin2, plugin3, plugin1);
+        FacetRegistry facetRegistry = new FacetRegistry(plugins);
+        PluginSortStrategy strategy = new PluginSortStrategy(facetRegistry);
         List<Plugin> orderedPlugins = strategy.sortPlugins(plugins);
 
-        assertThat(orderedPlugins).isNotNull();
-        assertThat(orderedPlugins).containsOnly(b, c, d);
-        assertThat(orderedPlugins).containsSequence(b, d, c );
+        // Assert the old order
+        assertThat(plugins).containsSequence(plugin4, plugin2, plugin3, plugin1);
+        // Assert the new order
+        assertThat(orderedPlugins).containsSequence(plugin1, plugin2, plugin3, plugin4);
+    }
+
+    private static class Plugin1 extends TestPlugin {
+
+        public Plugin1() {
+            index = 1;
+        }
+
+        @Override
+        public Collection<Class<?>> dependentPlugins() {
+            return Lists.<Class<?>>newArrayList(Facet1.class);
+        }
+    }
+
+    @Facet
+    private static interface Facet1 { }
+
+    private static class Plugin2 extends TestPlugin implements Facet1 {
+
+        public Plugin2() {
+            index = 2;
+        }
+    }
+
+    private static class Plugin3 extends TestPlugin {
+
+        public Plugin3() {
+            index = 3;
+        }
+
+        @Override
+        public Collection<Class<?>> dependentPlugins() {
+            return Lists.<Class<?>>newArrayList(Plugin4.class);
+        }
+
+        @Override
+        public Collection<Class<?>> requiredPlugins() {
+            return Lists.<Class<?>>newArrayList(Facet1.class);
+        }
+    }
+
+    private static class Plugin4 extends TestPlugin {
+
+        public Plugin4() {
+            index = 4;
+        }
+    }
+
+    private static class TestPlugin extends AbstractPlugin {
+
+        protected int index;
+
+        @Override
+        public String name() {
+            return "P" + index;
+        }
+
+        @Override
+        public String toString() {
+            return name();
+        }
     }
 }

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
@@ -19,9 +19,9 @@
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Module;
 import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -153,11 +153,10 @@ public class DummyPlugin extends AbstractPlugin
         return kernelParamsRequestBuilder().mandatory("dummy.plugin1").build();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins()
+    public Collection<Class<?>> requiredPlugins()
     {
-        return collectionOf(DummyPlugin2.class);
+        return Lists.<Class<?>>newArrayList(DummyPlugin2.class);
     }
 
     @Override

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
@@ -19,55 +19,39 @@
  */
 package io.nuun.kernel.core.pluginsit.dummy23;
 
-import static org.fest.assertions.Assertions.assertThat;
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 
 import java.util.Collection;
 
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Epo Jemba
- * 
  */
 public class DummyPlugin2 extends AbstractPlugin
 {
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.nuunframework.kernel.plugin.AbstractPlugin#name()
-     */
     @Override
     public String name()
     {
         return "dummyPlugin2";
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.nuunframework.kernel.plugin.AbstractPlugin#pluginsRequired()
-     */
-    @SuppressWarnings({
-        "unchecked", "rawtypes"
-    })
     @Override
-    public Collection<Class<? extends Plugin>> requiredPlugins()
+    public Collection<Class<?>> requiredPlugins()
     {
-        return (Collection) collectionOf(DummyPlugin3.class);
+        return Lists.<Class<?>>newArrayList(DummyPlugin3.class);
     }
-    
-    
+
     @Override
     public InitState init(InitContext initContext)
     {
-        assertThat( initContext.pluginsRequired() ).isNotNull();
-        assertThat( initContext.pluginsRequired() ).hasSize(1);
-        assertThat( initContext.pluginsRequired().iterator().next().getClass() ).isEqualTo(DummyPlugin3.class);
+        assertThat(initContext.pluginsRequired()).isNotNull();
+        assertThat(initContext.pluginsRequired()).hasSize(1);
+        assertThat(initContext.pluginsRequired().iterator().next().getClass()).isEqualTo(DummyPlugin3.class);
         return InitState.INITIALIZED;
     }
-
 }

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
@@ -16,7 +16,7 @@
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.BindingRequest;
@@ -45,14 +45,13 @@ public class DummyPlugin6_B extends AbstractPlugin
     {
         return "dummy-plugin-6-B";
     }
-    
-    @SuppressWarnings("unchecked")
+
     @Override
-    public Collection<Class<? extends Plugin>> dependentPlugins()
+    public Collection<Class<?>> dependentPlugins()
     {
         if (round != null && round.isFirst())
         {
-            return collectionOf(DummyPlugin6_D.class, DummyPlugin6_C.class);
+            return Lists.<Class<?>>newArrayList(DummyPlugin6_D.class, DummyPlugin6_C.class);
         }
         else
         {
@@ -86,7 +85,7 @@ public class DummyPlugin6_B extends AbstractPlugin
     {
         if (round.number() != 5)
         {
-            Collection<? extends Plugin> dependentPlugins = initContext.dependentPlugins();
+            Collection<?> dependentPlugins = initContext.dependentPlugins();
             assertThat(dependentPlugins).isNotNull();
             if (round.isFirst())
             {
@@ -108,7 +107,7 @@ public class DummyPlugin6_B extends AbstractPlugin
                 assertThat(collection).isNullOrEmpty();
             }
 
-            for (Plugin plugin : dependentPlugins)
+            for (Object plugin : dependentPlugins)
             {
                 if (DummyPlugin6_D.class.isAssignableFrom(plugin.getClass())) 
                 {

--- a/core/src/test/java/it/PluginDependencyIT.java
+++ b/core/src/test/java/it/PluginDependencyIT.java
@@ -4,10 +4,7 @@ import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.config.KernelConfiguration;
 import io.nuun.kernel.core.KernelException;
 import io.nuun.kernel.core.NuunCore;
-import it.fixture.dependencies.DependentPlugin1;
-import it.fixture.dependencies.RequiredPlugin1;
-import it.fixture.dependencies.WithDependentDepsPlugin;
-import it.fixture.dependencies.WithRequiredDepsPlugin;
+import it.fixture.dependencies.*;
 import org.junit.Test;
 
 /**
@@ -66,6 +63,20 @@ public class PluginDependencyIT {
         KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
                 .withoutSpiPluginsLoader()
                 .addPlugin(WithRequiredDepsPlugin.class);
+
+        Kernel kernel = NuunCore.createKernel(kernelConfig);
+        kernel.init();
+    }
+
+    /**
+     * WithDependentDepsPlugin throws an exception if DependentPlugin1 is initialized before it.
+     */
+    @Test
+    public void test_required_facet() {
+        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
+                .withoutSpiPluginsLoader()
+                .addPlugin(Facet1Plugin.class)
+                .addPlugin(WithRequiredFacetPlugin.class);
 
         Kernel kernel = NuunCore.createKernel(kernelConfig);
         kernel.init();

--- a/core/src/test/java/it/fixture/dependencies/Facet1.java
+++ b/core/src/test/java/it/fixture/dependencies/Facet1.java
@@ -1,0 +1,12 @@
+package it.fixture.dependencies;
+
+import io.nuun.kernel.api.annotations.Facet;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Facet
+public interface Facet1 {
+
+    boolean isInitialized();
+}

--- a/core/src/test/java/it/fixture/dependencies/Facet1Plugin.java
+++ b/core/src/test/java/it/fixture/dependencies/Facet1Plugin.java
@@ -1,0 +1,30 @@
+package it.fixture.dependencies;
+
+import io.nuun.kernel.api.plugin.InitState;
+import io.nuun.kernel.api.plugin.context.InitContext;
+import io.nuun.kernel.core.AbstractPlugin;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class Facet1Plugin extends AbstractPlugin implements Facet1 {
+
+    public static final String NAME = "facet-1";
+
+    private boolean initialized = false;
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public InitState init(InitContext initContext) {
+        initialized = true;
+        return InitState.INITIALIZED;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
@@ -1,13 +1,11 @@
 package it.fixture.dependencies;
 
-import io.nuun.kernel.api.Plugin;
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
@@ -25,7 +23,7 @@ public class WithDependentDepsPlugin extends AbstractPlugin {
     public InitState init(InitContext initContext) {
         boolean isInitialized = false;
 
-        for (Plugin plugin : initContext.pluginsRequired()) {
+        for (Object plugin : initContext.pluginsRequired()) {
             if (plugin instanceof DependentPlugin1){
                 isInitialized = ((DependentPlugin1) plugin).isInitialized();
             }
@@ -39,9 +37,7 @@ public class WithDependentDepsPlugin extends AbstractPlugin {
     }
 
     @Override
-    public Collection<Class<? extends Plugin>> dependentPlugins() {
-        List<Class<? extends Plugin>> dependents = new ArrayList<Class<? extends Plugin>>();
-        dependents.add(DependentPlugin1.class);
-        return dependents;
+    public Collection<Class<?>> dependentPlugins() {
+        return Lists.<Class<?>>newArrayList(DependentPlugin1.class);
     }
 }

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
@@ -35,10 +35,15 @@ public class WithRequiredFacetPlugin extends AbstractPlugin {
             throw new IllegalStateException("WithRequiredFacetPlugin should have only one dependency");
         }
 
+        List<Facet1> facet1s = initContext.dependencies(Facet1.class);
+        if (facet1s.size() != 1) {
+            throw new IllegalStateException("WithRequiredFacetPlugin should have only one dependency");
+        }
+
         return InitState.INITIALIZED;
     }
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(Facet1Plugin.class);
+        return Lists.<Class<?>>newArrayList(Facet1.class);
     }
 }

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
@@ -6,11 +6,12 @@ import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.core.AbstractPlugin;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
-public class WithRequiredDepsPlugin extends AbstractPlugin {
+public class WithRequiredFacetPlugin extends AbstractPlugin {
 
     public static final String NAME = "with-required-deps";
 
@@ -19,26 +20,25 @@ public class WithRequiredDepsPlugin extends AbstractPlugin {
         return NAME;
     }
 
+
     @Override
     public InitState init(InitContext initContext) {
-        boolean isInitialized = false;
 
-        for (Object plugin : initContext.pluginsRequired()) {
-            if (plugin instanceof RequiredPlugin1){
-                isInitialized = ((RequiredPlugin1) plugin).isInitialized();
-            }
+        Facet1 facet1 = initContext.dependency(Facet1.class);
+
+        if (!facet1.isInitialized()) {
+            throw new IllegalStateException("Facet1 should be initialized before WithRequiredFacetPlugin");
         }
 
-        if (!isInitialized) {
-            throw new IllegalStateException("RequiredPlugin1 should not be initialized before WithRequiredDepsPlugin");
+        List<?> dependencies = initContext.dependencies();
+        if (dependencies.size() != 1) {
+            throw new IllegalStateException("WithRequiredFacetPlugin should have only one dependency");
         }
 
         return InitState.INITIALIZED;
     }
-
     @Override
     public Collection<Class<?>> requiredPlugins() {
-        return Lists.<Class<?>>newArrayList(RequiredPlugin1.class);
+        return Lists.<Class<?>>newArrayList(Facet1Plugin.class);
     }
-
 }

--- a/specs/src/main/java/io/nuun/kernel/api/Plugin.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Plugin.java
@@ -95,7 +95,7 @@ public interface Plugin
      * 
      * @return the required plugin classes
      */
-    Collection<Class<? extends Plugin>> requiredPlugins();
+    Collection<Class<?>> requiredPlugins();
 
     /**
      * List of plugins that become dependent on "this" plugin.
@@ -103,7 +103,7 @@ public interface Plugin
      * 
      * @return the dependent plugin classes
      */
-    Collection<Class<? extends Plugin>> dependentPlugins();
+    Collection<Class<?>> dependentPlugins();
 
     /**
      * The prefix for all the properties for this plugin.

--- a/specs/src/main/java/io/nuun/kernel/api/annotations/Facet.java
+++ b/specs/src/main/java/io/nuun/kernel/api/annotations/Facet.java
@@ -1,0 +1,14 @@
+package io.nuun.kernel.api.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * The facet annotation is used to mark interfaces exposing a plugin API.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Facet {
+}

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
@@ -83,6 +83,8 @@ public interface InitContext
 
     List<?> dependencies();
 
+    <T> List<T> dependencies(Class<T> dependencyClass);
+
     <T> T dependency(Class<T> dependencyClass);
     /**
      * The current initialization round.

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
@@ -33,33 +33,35 @@ import java.util.Map;
 public interface InitContext
 {
 
-    public abstract Map<Class<?>, Collection<Class<?>>> scannedSubTypesByParentClass();
+    Map<Class<?>, Collection<Class<?>>> scannedSubTypesByParentClass();
 
-    public abstract Map<Class<?>, Collection<Class<?>>> scannedSubTypesByAncestorClass();
+    Map<Class<?>, Collection<Class<?>>> scannedSubTypesByAncestorClass();
     
-    public abstract Map<String, Collection<Class<?>>> scannedSubTypesByParentRegex();
+    Map<String, Collection<Class<?>>> scannedSubTypesByParentRegex();
 
-    public abstract Map<Class<? extends Annotation>, Collection<Class<?>>> scannedClassesByAnnotationClass();
+    Map<Class<? extends Annotation>, Collection<Class<?>>> scannedClassesByAnnotationClass();
 
-    public abstract Map<String, Collection<Class<?>>> scannedClassesByAnnotationRegex();
+    Map<String, Collection<Class<?>>> scannedClassesByAnnotationRegex();
 
-    public abstract Map<String, Collection<String>> mapPropertiesFilesByPrefix();
+    Map<String, Collection<String>> mapPropertiesFilesByPrefix();
 
-    public abstract String kernelParam(String key);
+    Map<String, String> kernelParams();
 
-    public abstract Collection<Class<?>> classesToBind();
+    String kernelParam(String key);
 
-    public abstract List<UnitModule> moduleResults();
+    Collection<Class<?>> classesToBind();
+
+    List<UnitModule> moduleResults();
     
-    public abstract List<UnitModule> moduleOverridingResults();
+    List<UnitModule> moduleOverridingResults();
 
-    public abstract Collection<String> propertiesFiles();
+    Collection<String> propertiesFiles();
 
-    public abstract Map<String, Collection<Class<?>>> scannedTypesByRegex();
+    Map<String, Collection<Class<?>>> scannedTypesByRegex();
 
-    public abstract Map<String, Collection<String>> mapResourcesByRegex();
+    Map<String, Collection<String>> mapResourcesByRegex();
 
-    public abstract Map<Specification, Collection<Class<?>>> scannedTypesBySpecification();
+    Map<Specification, Collection<Class<?>>> scannedTypesBySpecification();
     
     /**
      * Returns plugin instances required by the current plugin.
@@ -68,7 +70,7 @@ public interface InitContext
      * @return the instances of the plugin declared required by the method Plugin.pluginDependenciesRequired()
      */
     @Deprecated
-    public abstract Collection<?> pluginsRequired();
+    Collection<?> pluginsRequired();
     
     /**
      * Returns instances of the plugins that become dependent on this plugin.
@@ -77,16 +79,16 @@ public interface InitContext
      * @return dependent plugins
      */
     @Deprecated
-    public abstract Collection<?> dependentPlugins();
+    Collection<?> dependentPlugins();
 
-    public abstract List<?> dependencies();
+    List<?> dependencies();
 
-    public abstract <T> T dependency(Class<T> dependencyClass);
+    <T> T dependency(Class<T> dependencyClass);
     /**
      * The current initialization round.
      * 
      * @return the current round number
      */
-    public abstract int roundNumber();
+    int roundNumber();
 
 }

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
@@ -16,7 +16,6 @@
  */
 package io.nuun.kernel.api.plugin.context;
 
-import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.di.UnitModule;
 import org.kametic.specifications.Specification;
 
@@ -68,8 +67,8 @@ public interface InitContext
      * 
      * @return the instances of the plugin declared required by the method Plugin.pluginDependenciesRequired()
      */
-    public abstract Collection<? extends Plugin> pluginsRequired();
-
+    @Deprecated
+    public abstract Collection<?> pluginsRequired();
     
     /**
      * Returns instances of the plugins that become dependent on this plugin.
@@ -77,8 +76,12 @@ public interface InitContext
      * 
      * @return dependent plugins
      */
-    public abstract Collection<? extends Plugin> dependentPlugins();
+    @Deprecated
+    public abstract Collection<?> dependentPlugins();
 
+    public abstract List<?> dependencies();
+
+    public abstract <T> T dependency(Class<T> dependencyClass);
     /**
      * The current initialization round.
      * 


### PR DESCRIPTION
**Usage:**

Implement an interface annotated by `@Facet`
```
@Facet
public interface Facet1 { ... }
```

Create a plugin which implements the facet.

```
public class Facet1Plugin extends AbstractPlugin implements Facet1 { ... }
```

Then create a new plugin declaring the facet as required. And get it via the `InitContext`.

```java
public class WithRequiredFacetPlugin extends AbstractPlugin {

    @Override
    public String name() {
        return "with-required-deps";
    }

    @Override
    public InitState init(InitContext initContext) {
        Facet1 facet1 = initContext.dependency(Facet1.class);
        ...
        List<?> dependencies = initContext.dependencies();
        ...
        return InitState.INITIALIZED;
    }
    @Override
    public Collection<Class<?>> requiredPlugins() {
        return Lists.<Class<?>>newArrayList(Facet1Plugin.class);
    }
}
```