### PR TITLE
Update to official Guice 4.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,22 +38,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.sonatype.sisu</groupId>
-			<artifactId>sisu-guice</artifactId>
-			<version>3.1.3</version>
-		</dependency> 
-		<dependency>
-			<groupId>aopalliance</groupId>
-			<artifactId>aopalliance</artifactId>
-			<version>1.0</version>
+			<groupId>com.google.inject</groupId>
+			<artifactId>guice</artifactId>
+			<version>4.0</version>
 		</dependency>
-		<!-- Same version as sisu guice -->
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>13.0.1</version>
-		</dependency>
-
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.6</version>
+      <version>1.7.16</version>
     </dependency>
     
     <!-- ========================================================== -->


### PR DESCRIPTION
This PR updates Guice to the official version 4.0. This is required to solve seedstack/seed#191.

Two reasons for moving to official build:
- Every feature we require from Guice is now in the official build
- From what I undertstand, the sisu Guice is a mix of patches from the official Guice trunk AND internal sonatype patches for compatibility with their legacy (https://groups.google.com/forum/?fromgroups#!topic/google-guice/Wz1XrRuX69U). Using the official build is cleaner IMO.

I tested Guice 4.0 with SeedStack and after patching the Shiro integration, everything seems ok, so we don't have any blocking issue to move to version 4.0 (and the future nuun 1.0).

This also updates SLF4J API to latest version (no breaking change).