### PR TITLE
Plugin license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ cache:
 notifications:
   irc: "chat.freenode.net#nuun-dev"
 
-script: mvn -B verify jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN
+script: mvn -B -q verify jacoco:report
 
 after_success:
+  - mvn -q coveralls:report -DrepoToken=$COVERALLS_TOKEN
   - echo "<settings><servers><server><id>sonatype-nexus-snapshots</id><username>\${env.SONATYPE_USER}</username><password>\${env.SONATYPE_PASS}</password></server></servers></settings>" > ~/settings.xml
   - "[[ $TRAVIS_PULL_REQUEST == \"false\" && $TRAVIS_BRANCH == \"master\" ]] && mvn deploy --settings ~/settings.xml"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,3 +1,21 @@
+<!--
+
+    This file is part of Nuun IO Kernel Core.
+
+    Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel Core is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
+++ b/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/main/java/io/nuun/kernel/core/KernelException.java
+++ b/core/src/main/java/io/nuun/kernel/core/KernelException.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/main/java/io/nuun/kernel/core/NuunCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/NuunCore.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/AliasMap.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/AliasMap.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.core.KernelException;

--- a/core/src/main/java/io/nuun/kernel/core/internal/ContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ContextInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependenciesSpecification.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependenciesSpecification.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.ArrayListMultimap;

--- a/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.ArrayListMultimap;

--- a/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
- * <p/>
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p/>
- * http://www.gnu.org/licenses/lgpl-3.0.txt
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCoreFactory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCoreFactory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/MandatoryParamsSpecification.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/MandatoryParamsSpecification.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/main/java/io/nuun/kernel/core/internal/RequestHandler.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/RequestHandler.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.base.Strings;

--- a/core/src/main/java/io/nuun/kernel/core/internal/ScanResults.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ScanResults.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.di.UnitModule;

--- a/core/src/main/java/io/nuun/kernel/core/internal/State.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/State.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 /**

--- a/core/src/main/java/io/nuun/kernel/core/internal/graph/Graph.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/graph/Graph.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.graph;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/graph/Vertex.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/graph/Vertex.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.graph;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/ClassInstaller.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/ClassInstaller.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.Binder;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/Installer.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/Installer.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.Binder;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/InstallerFactory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/InstallerFactory.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import io.nuun.kernel.api.di.UnitModule;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/KernelGuiceModuleInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/KernelGuiceModuleInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.injection;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleEmbedded.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleEmbedded.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import io.nuun.kernel.api.di.GlobalModule;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleHandler.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleHandler.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.common.collect.Maps;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/ObjectGraphEmbedded.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/ObjectGraphEmbedded.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.Injector;

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/UnitModuleInstaller.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/UnitModuleInstaller.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.Binder;

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/AbstractClasspathScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/AbstractClasspathScanner.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScanner.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerFactory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerFactory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/IgnorePredicate.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/IgnorePredicate.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.scanner;
 
 import com.google.common.base.Predicate;

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/ScanResult.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/ScanResult.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.scanner;
 
 import com.google.inject.Scopes;

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.disk;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathStrategy.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathStrategy.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.scanner.disk;
 
 public class ClasspathStrategy {

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/MetaAnnotationScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/MetaAnnotationScanner.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.disk;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/NameAnnotationScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/NameAnnotationScanner.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.disk;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathBuilder.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathBuilder.java
@@ -1,10 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com> Licensed under the GNU LESSER GENERAL PUBLIC LICENSE,
- * Version 3, 29 June 2007; or any later version you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at http://www.gnu.org/licenses/lgpl-3.0.txt Unless required
- * by applicable law or agreed to in writing, software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
- * the specific language governing permissions and limitations under the License.
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryClass.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryClass.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFactory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFactory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFile.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFile.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryHandler.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryHandler.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 
 import java.io.IOException;

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryMultiThreadClasspath.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryMultiThreadClasspath.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryResource.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryResource.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlType.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/MetadataAdapterInMemory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/MetadataAdapterInMemory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/utils/AssertUtils.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/utils/AssertUtils.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.utils;
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/utils/NuunReflectionUtils.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/utils/NuunReflectionUtils.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.utils;
 
 

--- a/core/src/main/java/io/nuun/kernel/core/package-info.java
+++ b/core/src/main/java/io/nuun/kernel/core/package-info.java
@@ -1,20 +1,19 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 /**
  * 
  * 

--- a/core/src/test/java/io/nuun/kernel/core/AbstractFixture.java
+++ b/core/src/test/java/io/nuun/kernel/core/AbstractFixture.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/test/java/io/nuun/kernel/core/CoreITFixture.java
+++ b/core/src/test/java/io/nuun/kernel/core/CoreITFixture.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite7Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite7Test.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite8Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite8Test.java
@@ -1,10 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com> Licensed under the GNU LESSER GENERAL PUBLIC LICENSE,
- * Version 3, 29 June 2007; or any later version you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at http://www.gnu.org/licenses/lgpl-3.0.txt Unless required
- * by applicable law or agreed to in writing, software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
- * the specific language governing permissions and limitations under the License.
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/AliasMapTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/AliasMapTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/test/java/io/nuun/kernel/core/internal/Fixture.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/Fixture.java
@@ -1,18 +1,18 @@
-/*
- * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelConfigurationTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelConfigurationTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelMulticoreTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelMulticoreTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import io.nuun.kernel.api.Plugin;

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
- * <p/>
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p/>
- * http://www.gnu.org/licenses/lgpl-3.0.txt
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/BugConcern.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/BugConcern.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/BugPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/BugPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/CacheConcern.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/CacheConcern.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/CachePlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/CachePlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/ConcernInterceptor.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/ConcernInterceptor.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/LogConcern.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/LogConcern.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/LogPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/LogPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/SecurityConcern.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/SecurityConcern.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/SecurityPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/sample/SecurityPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.concerns.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/injection/ClassInstallerTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/injection/ClassInstallerTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.Scopes;

--- a/core/src/test/java/io/nuun/kernel/core/internal/injection/ModuleInstallerTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/injection/ModuleInstallerTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.injection;
 
 import com.google.inject.AbstractModule;

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerTestBase.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerTestBase.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/IgnorePolicyTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/IgnorePolicyTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.core.internal.scanner;
 
 import io.nuun.kernel.api.annotations.Ignore;

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemoryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemoryTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
- * <p/>
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p/>
- * http://www.gnu.org/licenses/lgpl-3.0.txt
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryClasspathBuilderTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryClasspathBuilderTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFactoryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryFactoryTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlTypeTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlTypeTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.inmemory;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/reflections/ClasspathScannerReflectionsTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/reflections/ClasspathScannerReflectionsTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.reflections;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean1.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean2.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean3.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean4.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean4.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean5.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean5.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean6.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Bean6.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/DummyMethod.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/DummyMethod.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 import static java.lang.annotation.ElementType.METHOD;

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderChild.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderChild.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForBeanWithParentType.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForBeanWithParentType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForContext.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForContext.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForError.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForError.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForInterface.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForPrefixWithName.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/HolderForPrefixWithName.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Ignore.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/Ignore.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ModuleInError.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ModuleInError.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ModuleInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ModuleInterface.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule1.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule2.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule3.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule4.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/MyModule4.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/OtherScanMarkerSample.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/OtherScanMarkerSample.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ScanMarkerSample.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ScanMarkerSample.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ScanMarkerSample2.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/sample/ScanMarkerSample2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.scanner.sample;
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/utils/AssertUtilsTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/utils/AssertUtilsTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.internal.utils;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean10.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean10.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean11.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean11.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean6.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean6.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean7.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean7.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean8.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean8.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean9.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/Bean9.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/BeanWithCustomSuffix.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/BeanWithCustomSuffix.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/BeanWithParentType.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/BeanWithParentType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyMarker.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyMarker.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyModule.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyModule.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyService.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyService.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyServiceInternal.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyServiceInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyServiceInternal2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyServiceInternal2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/InterfaceWithCustom2Suffix.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/InterfaceWithCustom2Suffix.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/MarkerSample3.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/MarkerSample3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/MarkerSample4.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/MarkerSample4.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/ParentClassWithCustomSuffix.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/ParentClassWithCustomSuffix.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/ParentInterfaceWithCustomSuffix.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/ParentInterfaceWithCustomSuffix.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy1;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin3.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  *

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/DummyPlugin4.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/DummyPlugin4.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Interface1.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Interface1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Interface2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Interface2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/MarkerSample5.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/MarkerSample5.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Pojo1.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Pojo1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Pojo2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/Pojo2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy4;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DescendantFromClass.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DescendantFromClass.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DescendantFromInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DescendantFromInterface.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DummyPlugin5.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DummyPlugin5.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/GrandParentClass.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/GrandParentClass.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/GrandParentInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/GrandParentInterface.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/MetaMarkerSample.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/MetaMarkerSample.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ParentClass.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ParentClass.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ParentInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ParentInterface.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ToFind.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ToFind.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ToFind2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/ToFind2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/XMarkerSample6.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/XMarkerSample6.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/YMarkerSample6.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/YMarkerSample6.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/YMetaMarkerSample.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/YMetaMarkerSample.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy5;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_A.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_A.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_C.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_C.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_D.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_D.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/Marker6.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/Marker6.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/Marker66.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/Marker66.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T1.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T3.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/T3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy6;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/DummyPlugin7_A.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/DummyPlugin7_A.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy7;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/DummyPlugin7_B.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/DummyPlugin7_B.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy7;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/Module7.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy7/Module7.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.core.pluginsit.dummy7;
 

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/DummyExtensionPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/DummyExtensionPlugin.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.core.pluginsit.extension;
 
 import io.nuun.kernel.core.AbstractPlugin;

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyExtensionInterface.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyExtensionInterface.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.core.pluginsit.extension;
 
 /**

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Core.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.core.pluginsit.extension;
 
 import io.nuun.kernel.spi.KernelExtension;

--- a/core/src/test/java/it/AliasIT.java
+++ b/core/src/test/java/it/AliasIT.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it;
 
 import io.nuun.kernel.api.Kernel;

--- a/core/src/test/java/it/ClasspathScanningIT.java
+++ b/core/src/test/java/it/ClasspathScanningIT.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/it/MainInjectorIT.java
+++ b/core/src/test/java/it/MainInjectorIT.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it;
 
 import com.google.inject.Injector;

--- a/core/src/test/java/it/PluginDependencyIT.java
+++ b/core/src/test/java/it/PluginDependencyIT.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it;
 
 import io.nuun.kernel.core.KernelException;

--- a/core/src/test/java/it/PluginDiscoveryIT.java
+++ b/core/src/test/java/it/PluginDiscoveryIT.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it;
 
 import io.nuun.kernel.api.Kernel;

--- a/core/src/test/java/it/fixture/NoOpPlugin1.java
+++ b/core/src/test/java/it/fixture/NoOpPlugin1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture;
 
 import io.nuun.kernel.core.AbstractPlugin;

--- a/core/src/test/java/it/fixture/NoOpPlugin2.java
+++ b/core/src/test/java/it/fixture/NoOpPlugin2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture;
 
 import io.nuun.kernel.core.AbstractPlugin;

--- a/core/src/test/java/it/fixture/dependencies/DependentPlugin1.java
+++ b/core/src/test/java/it/fixture/dependencies/DependentPlugin1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import io.nuun.kernel.api.plugin.InitState;

--- a/core/src/test/java/it/fixture/dependencies/Facet1.java
+++ b/core/src/test/java/it/fixture/dependencies/Facet1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import io.nuun.kernel.api.annotations.Facet;

--- a/core/src/test/java/it/fixture/dependencies/Facet1Plugin.java
+++ b/core/src/test/java/it/fixture/dependencies/Facet1Plugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import io.nuun.kernel.api.plugin.InitState;

--- a/core/src/test/java/it/fixture/dependencies/RequiredPlugin1.java
+++ b/core/src/test/java/it/fixture/dependencies/RequiredPlugin1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import io.nuun.kernel.api.plugin.InitState;

--- a/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredDepsPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredDepsPlugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.dependencies;
 
 import com.google.common.collect.Lists;

--- a/core/src/test/java/it/fixture/injection/InjectableInterface1.java
+++ b/core/src/test/java/it/fixture/injection/InjectableInterface1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 /**

--- a/core/src/test/java/it/fixture/injection/InjectableInterface2.java
+++ b/core/src/test/java/it/fixture/injection/InjectableInterface2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 /**

--- a/core/src/test/java/it/fixture/injection/InjecteeImplementation1.java
+++ b/core/src/test/java/it/fixture/injection/InjecteeImplementation1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 /**

--- a/core/src/test/java/it/fixture/injection/InjecteeImplementation2.java
+++ b/core/src/test/java/it/fixture/injection/InjecteeImplementation2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 /**

--- a/core/src/test/java/it/fixture/injection/InjectionPlugin1.java
+++ b/core/src/test/java/it/fixture/injection/InjectionPlugin1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 import com.google.inject.Binder;

--- a/core/src/test/java/it/fixture/injection/InjectionPlugin2.java
+++ b/core/src/test/java/it/fixture/injection/InjectionPlugin2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.injection;
 
 import com.google.inject.Binder;

--- a/core/src/test/java/it/fixture/scan/ClassNotToScan1.java
+++ b/core/src/test/java/it/fixture/scan/ClassNotToScan1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 import io.nuun.kernel.api.annotations.Ignore;

--- a/core/src/test/java/it/fixture/scan/ClassNotToScan2.java
+++ b/core/src/test/java/it/fixture/scan/ClassNotToScan2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 /**

--- a/core/src/test/java/it/fixture/scan/ClassToScan1.java
+++ b/core/src/test/java/it/fixture/scan/ClassToScan1.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 /**

--- a/core/src/test/java/it/fixture/scan/ClassToScan2.java
+++ b/core/src/test/java/it/fixture/scan/ClassToScan2.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 /**

--- a/core/src/test/java/it/fixture/scan/CustomIgnore.java
+++ b/core/src/test/java/it/fixture/scan/CustomIgnore.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 import io.nuun.kernel.api.annotations.Ignore;

--- a/core/src/test/java/it/fixture/scan/ScanningPlugin.java
+++ b/core/src/test/java/it/fixture/scan/ScanningPlugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 import io.nuun.kernel.api.plugin.InitState;

--- a/core/src/test/java/it/fixture/scan/ToScan.java
+++ b/core/src/test/java/it/fixture/scan/ToScan.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Core.
+ *
+ * Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package it.fixture.scan;
 
 import java.lang.annotation.*;

--- a/core/src/test/resources/META-INF/properties/tst-one.properties
+++ b/core/src/test/resources/META-INF/properties/tst-one.properties
@@ -1,17 +1,17 @@
 #
-# Copyright (C) 2013 Kametic <epo.jemba@kametic.com>
+# This file is part of Nuun IO Kernel Core.
 #
-# Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
-# or any later version
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# http://www.gnu.org/licenses/lgpl-3.0.txt
+# Nuun IO Kernel Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# You should have received a copy of the GNU Lesser General Public License
+# along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
 #
 

--- a/core/src/test/resources/META-INF/properties/tst-two.properties
+++ b/core/src/test/resources/META-INF/properties/tst-two.properties
@@ -1,17 +1,17 @@
 #
-# Copyright (C) 2013 Kametic <epo.jemba@kametic.com>
+# This file is part of Nuun IO Kernel Core.
 #
-# Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
-# or any later version
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# http://www.gnu.org/licenses/lgpl-3.0.txt
+# Nuun IO Kernel Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# You should have received a copy of the GNU Lesser General Public License
+# along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
 #
 

--- a/core/src/test/resources/META-INF/properties/tst_-three.properties
+++ b/core/src/test/resources/META-INF/properties/tst_-three.properties
@@ -1,17 +1,17 @@
 #
-# Copyright (C) 2013 Kametic <epo.jemba@kametic.com>
+# This file is part of Nuun IO Kernel Core.
 #
-# Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
-# or any later version
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# http://www.gnu.org/licenses/lgpl-3.0.txt
+# Nuun IO Kernel Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# You should have received a copy of the GNU Lesser General Public License
+# along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
 #
 

--- a/core/src/test/resources/internal/sample1-applicationContext-business.xml
+++ b/core/src/test/resources/internal/sample1-applicationContext-business.xml
@@ -1,18 +1,19 @@
 <!--
 
-    Copyright (C) 2013 Kametic <epo.jemba@kametic.com>
+    This file is part of Nuun IO Kernel Core.
 
-    Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
-    or any later version
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+    Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-    http://www.gnu.org/licenses/lgpl-3.0.txt
+    Nuun IO Kernel Core is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
 
+-->
 -->

--- a/core/src/test/resources/internal/sample2-applicationContext-persistence.xml
+++ b/core/src/test/resources/internal/sample2-applicationContext-persistence.xml
@@ -1,18 +1,19 @@
 <!--
 
-    Copyright (C) 2013 Kametic <epo.jemba@kametic.com>
+    This file is part of Nuun IO Kernel Core.
 
-    Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
-    or any later version
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+    Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-    http://www.gnu.org/licenses/lgpl-3.0.txt
+    Nuun IO Kernel Core is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
 
+-->
 -->

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0"?>
+<!--
+
+    This file is part of Nuun IO Kernel Core.
+
+    Nuun IO Kernel Core is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel Core is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Core.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,21 @@
+<!--
+
+    This file is part of Nuun IO Kernel.
+
+    Nuun IO Kernel is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,6 +68,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
+
+        <license-check.skip>false</license-check.skip>
+        <license-check.fail>true</license-check.fail>
+        <license-header-check.skip>false</license-header-check.skip>
+        <mycila.license-maven-plugin.version>2.10</mycila.license-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -145,6 +168,32 @@
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>${mycila.license-maven-plugin.version}</version>
+                <configuration>
+                    <header>com/mycila/maven/plugin/license/templates/LGPL-3.txt</header>
+                    <strictCheck>true</strictCheck>
+                    <keywords>
+                        <keyword>Copyright</keyword>
+                    </keywords>
+                    <useDefaultExcludes>true</useDefaultExcludes>
+                    <excludes>
+                        <exclude>LICENSE</exclude>
+                        <exclude>**/*.md</exclude>
+                    </excludes>
+                    <skip>${license-header-check.skip}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>check-license-header</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -1,3 +1,21 @@
+<!--
+
+    This file is part of Nuun IO Kernel Specs.
+
+    Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/specs/src/main/java/io/nuun/kernel/api/Kernel.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Kernel.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api;
 

--- a/specs/src/main/java/io/nuun/kernel/api/Plugin.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Plugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api;
 

--- a/specs/src/main/java/io/nuun/kernel/api/annotations/Facet.java
+++ b/specs/src/main/java/io/nuun/kernel/api/annotations/Facet.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.api.annotations;
 
 import java.lang.annotation.*;

--- a/specs/src/main/java/io/nuun/kernel/api/annotations/Ignore.java
+++ b/specs/src/main/java/io/nuun/kernel/api/annotations/Ignore.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.annotations;
 

--- a/specs/src/main/java/io/nuun/kernel/api/annotations/KernelModule.java
+++ b/specs/src/main/java/io/nuun/kernel/api/annotations/KernelModule.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.annotations;
 

--- a/specs/src/main/java/io/nuun/kernel/api/config/ClasspathScanMode.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/ClasspathScanMode.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.config;
 

--- a/specs/src/main/java/io/nuun/kernel/api/config/DependencyInjectionMode.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/DependencyInjectionMode.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.config;
 

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
- * <p/>
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p/>
- * http://www.gnu.org/licenses/lgpl-3.0.txt
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.config;
 

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelOption.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelOption.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.api.config;
 
 

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.api.config;
 
 import java.util.ArrayList;

--- a/specs/src/main/java/io/nuun/kernel/api/di/GlobalModule.java
+++ b/specs/src/main/java/io/nuun/kernel/api/di/GlobalModule.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.di;
 

--- a/specs/src/main/java/io/nuun/kernel/api/di/ModuleValidation.java
+++ b/specs/src/main/java/io/nuun/kernel/api/di/ModuleValidation.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.di;
 

--- a/specs/src/main/java/io/nuun/kernel/api/di/ModuleWrapper.java
+++ b/specs/src/main/java/io/nuun/kernel/api/di/ModuleWrapper.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.di;
 

--- a/specs/src/main/java/io/nuun/kernel/api/di/ObjectGraph.java
+++ b/specs/src/main/java/io/nuun/kernel/api/di/ObjectGraph.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.di;
 

--- a/specs/src/main/java/io/nuun/kernel/api/di/UnitModule.java
+++ b/specs/src/main/java/io/nuun/kernel/api/di/UnitModule.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.di;
 /**

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/Classpath.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/Classpath.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractContainer.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractContainer.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractElement.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractElement.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathClass.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathClass.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathDirectory.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathDirectory.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathJar.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathJar.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathResource.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathResource.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/Resource.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/Resource.java
@@ -1,10 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com> Licensed under the GNU LESSER GENERAL PUBLIC LICENSE,
- * Version 3, 29 June 2007; or any later version you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at http://www.gnu.org/licenses/lgpl-3.0.txt Unless required
- * by applicable law or agreed to in writing, software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for
- * the specific language governing permissions and limitations under the License.
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.inmemory;
 

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/package-info.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/package-info.java
@@ -1,20 +1,19 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/package-info.java
+++ b/specs/src/main/java/io/nuun/kernel/api/package-info.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/InitState.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/InitState.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/PluginException.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/PluginException.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/Round.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/Round.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/RoundInternal.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/RoundInternal.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/Context.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/Context.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.context;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.context;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/package-info.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/package-info.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * @author epo.jemba{@literal @}kametic.com

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequest.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
- * <p/>
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p/>
- * http://www.gnu.org/licenses/lgpl-3.0.txt
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  *

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequestBuilder.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingType.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/Builder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/Builder.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequest.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequestBuilder.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequest.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestBuilder.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestType.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/RequestType.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/RequestType.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderBuild.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderBuild.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request.builders;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderMain.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderMain.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request.builders;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderOptions.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderOptions.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request.builders;
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderOptionsBuildMain.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderOptionsBuildMain.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.api.plugin.request.builders;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/Concern.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/Concern.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/DependencyInjectionProvider.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/DependencyInjectionProvider.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (C) 2014 Kametic <pierre.thirouin@gmail.com>
+/**
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package io.nuun.kernel.spi;
 
 import java.util.Collection;

--- a/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunBaseConfigurationPlugin.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunBaseConfigurationPlugin.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Specs.
+ *
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.spi.configuration;
 
 import java.util.Map;

--- a/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunConfigurationConverter.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunConfigurationConverter.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi.configuration;
 public interface NuunConfigurationConverter<T> {

--- a/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunDummyConverter.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunDummyConverter.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi.configuration;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunProperty.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunProperty.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi.configuration;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunPropertyConverter.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/configuration/NuunPropertyConverter.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.spi.configuration;
 

--- a/specs/src/main/java/io/nuun/kernel/spi/package-info.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/package-info.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Specs.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
 /**
  * @author epo.jemba{@literal @}kametic.com

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,3 +1,21 @@
+<!--
+
+    This file is part of Nuun IO Kernel Tests.
+
+    Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITModule.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITModule.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.internal;
 

--- a/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITPlugin.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.internal;
 

--- a/tests/src/main/java/io/nuun/kernel/tests/it/NuunITException.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/NuunITException.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.it;
 

--- a/tests/src/main/java/io/nuun/kernel/tests/it/NuunITRunner.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/NuunITRunner.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.it;
 

--- a/tests/src/main/java/io/nuun/kernel/tests/it/annotations/Expect.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/annotations/Expect.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Tests.
+ *
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.tests.it.annotations;
 
 import java.lang.annotation.Documented;

--- a/tests/src/main/java/io/nuun/kernel/tests/it/annotations/ITBind.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/annotations/ITBind.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Tests.
+ *
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.tests.it.annotations;
 
 import java.lang.annotation.Documented;

--- a/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithParams.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithParams.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Tests.
+ *
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.tests.it.annotations;
 
 import java.lang.annotation.*;

--- a/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithPlugins.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithPlugins.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Tests.
+ *
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package io.nuun.kernel.tests.it.annotations;
 

--- a/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithoutSpiPluginsLoader.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/it/annotations/WithoutSpiPluginsLoader.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Nuun IO Kernel Tests.
+ *
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package io.nuun.kernel.tests.it.annotations;
 
 import java.lang.annotation.Documented;

--- a/tests/src/main/resources/logback-test.xml
+++ b/tests/src/main/resources/logback-test.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0"?>
+<!--
+
+    This file is part of Nuun IO Kernel Tests.
+
+    Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
+
+-->
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/tests/src/test/java/io/nuun/kernel/tests/it/NuunITRunnerTest.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/it/NuunITRunnerTest.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.it;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/it/ServiceA.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/it/ServiceA.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.it;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/AbstractTestPlugin.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/AbstractTestPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/ConstructorPlugin.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/ConstructorPlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.constructor;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/ConstructorService.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/ConstructorService.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.constructor;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/Payload.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/constructor/Payload.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.constructor;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/SamplePlugin.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/SamplePlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1Impl.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1Impl.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1Provider.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service1Provider.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service2.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service2.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service2Impl.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service2Impl.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service3.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service3.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service3Provider.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service3Provider.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service4.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service4.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service4Provider.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/dummy/Service4Provider.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.dummy;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstancePlugin.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstancePlugin.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.instance;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstanceService.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstanceService.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.instance;
 

--- a/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstanceServiceImpl.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/ut/sample/instance/InstanceServiceImpl.java
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba{@literal @}kametic.com>
+ * This file is part of Nuun IO Kernel Tests.
  *
- * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
- * or any later version
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * http://www.gnu.org/licenses/lgpl-3.0.txt
+ * Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
  */
 package io.nuun.kernel.tests.ut.sample.instance;
 

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+    This file is part of Nuun IO Kernel Tests.
 
-    This file is part of SeedStack, An enterprise-oriented full development stack.
+    Nuun IO Kernel Tests is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-    This Source Code Form is subject to the terms of the Mozilla Public
-    License, v. 2.0. If a copy of the MPL was not distributed with this
-    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    Nuun IO Kernel Tests is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with Nuun IO Kernel Tests.  If not, see <http://www.gnu.org/licenses/>.
 
 -->
 <configuration>


### PR DESCRIPTION
Add the following plugin with the default LGPL-3 template. It will checks for the license header in all files.

```
<plugin>
  <groupId>com.mycila</groupId>
  <artifactId>license-maven-plugin</artifactId>
</plugin>
```

If the build fails run the commandes.

    mvn license:format

It will add the following header:

```
/**
 * This file is part of Nuun IO Kernel Specs.
 *
 * Nuun IO Kernel Specs is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Lesser General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
 *
 * Nuun IO Kernel Specs is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU Lesser General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public License
 * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
 */
```