### PR TITLE
Fix 59 root packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: java
 jdk:
   - openjdk6
   - openjdk7
-  - oraclejdk7
   - oraclejdk8
+
+cache:
+  directories: $HOME/.m2/repository
 
 notifications:
   irc: "chat.freenode.net#nuun-dev"

--- a/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
+++ b/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
@@ -228,6 +228,12 @@ public abstract class AbstractPlugin implements Plugin
     }
 
     @Override
+    public String rootPackages()
+    {
+        return "";
+    }
+
+    @Override
     public UnitModule unitModule()
     {
         return nativeUnitModule() != null ?  new ModuleEmbedded(nativeUnitModule()) : null;

--- a/core/src/main/java/io/nuun/kernel/core/NuunCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/NuunCore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
+ * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
  *
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
@@ -1,13 +1,13 @@
 /**
- * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
- *
+ * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ * <p/>
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.gnu.org/licenses/lgpl-3.0.txt
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,9 +18,7 @@ package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.ObjectArrays;
 import io.nuun.kernel.api.Plugin;
-import io.nuun.kernel.api.config.ClasspathScanMode;
-import io.nuun.kernel.api.config.DependencyInjectionMode;
-import io.nuun.kernel.api.config.KernelConfiguration;
+import io.nuun.kernel.api.config.*;
 import io.nuun.kernel.api.di.ModuleValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,11 +37,23 @@ public class KernelConfigurationInternal implements KernelConfiguration
     private List<Class<? extends Plugin>> pluginsClass = new ArrayList<Class<? extends Plugin>>();
     private Plugin[] plugins = new Plugin[0];
     private List<ModuleValidation> validations = new ArrayList<ModuleValidation>();
-    private ClasspathScanMode classpathScanMode = ClasspathScanMode.NOMINAL;
-    private boolean isPluginScanEnabled = true;
     private Object containerContext;
-    private DependencyInjectionMode dependencyInjectionMode = DependencyInjectionMode.PRODUCTION;
     private List<String> rootPackages = new ArrayList<String>();
+
+    private KernelOptions options = new KernelOptions();
+
+    @Override
+    public <T> KernelConfiguration option(KernelOption<T> option, T value)
+    {
+        options.set(option, value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public KernelOptions options()
+    {
+        return options;
+    }
 
     @Override
     public KernelConfiguration rootPackages(String... rootPackages)
@@ -133,28 +143,28 @@ public class KernelConfigurationInternal implements KernelConfiguration
     @Override
     public KernelConfiguration withoutSpiPluginsLoader()
     {
-        isPluginScanEnabled = false;
+        this.options.set(KernelOptions.SCAN_PLUGIN, false);
         return this;
     }
 
     @Override
     public KernelConfiguration withSpiPluginsLoader()
     {
-        isPluginScanEnabled = true;
+        this.options.set(KernelOptions.SCAN_PLUGIN, true);
         return this;
     }
 
     @Override
     public KernelConfiguration dependencyInjectionMode(DependencyInjectionMode dependencyInjectionMode)
     {
-        this.dependencyInjectionMode = dependencyInjectionMode;
+        this.options.set(KernelOptions.DEPENDENCY_INJECTION_MODE, dependencyInjectionMode);
         return this;
     }
 
     @Override
     public KernelConfiguration classpathScanMode(ClasspathScanMode classpathScanMode)
     {
-        this.classpathScanMode = classpathScanMode;
+        this.options.set(KernelOptions.CLASSPATH_SCAN_MODE, classpathScanMode);
         return this;
     }
 
@@ -190,17 +200,17 @@ public class KernelConfigurationInternal implements KernelConfiguration
 
     public boolean isPluginScanEnabled()
     {
-        return isPluginScanEnabled;
+        return options.get(KernelOptions.SCAN_PLUGIN);
     }
 
     public DependencyInjectionMode getDependencyInjectionMode()
     {
-        return dependencyInjectionMode;
+        return options.get(KernelOptions.DEPENDENCY_INJECTION_MODE);
     }
 
     public ClasspathScanMode getClasspathScanMode()
     {
-        return classpathScanMode;
+        return options.get(KernelOptions.CLASSPATH_SCAN_MODE);
     }
 
     public List<ModuleValidation> getValidations()

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
@@ -38,7 +38,6 @@ public class KernelConfigurationInternal implements KernelConfiguration
     private Plugin[] plugins = new Plugin[0];
     private List<ModuleValidation> validations = new ArrayList<ModuleValidation>();
     private Object containerContext;
-    private List<String> rootPackages = new ArrayList<String>();
 
     private KernelOptions options = new KernelOptions();
 
@@ -58,7 +57,7 @@ public class KernelConfigurationInternal implements KernelConfiguration
     @Override
     public KernelConfiguration rootPackages(String... rootPackages)
     {
-        this.rootPackages.addAll(Arrays.asList(rootPackages));
+        this.options.get(KernelOptions.ROOT_PACKAGES).addAll(Arrays.asList(rootPackages));
         return this;
     }
 
@@ -66,6 +65,9 @@ public class KernelConfigurationInternal implements KernelConfiguration
     public KernelConfiguration param(String key, String value)
     {
         kernelParamsAndAlias.put(key, value);
+        if (key.equals("nuun.root.package")) {
+            options.get(KernelOptions.ROOT_PACKAGES).add(value);
+        }
         return this;
     }
 
@@ -96,7 +98,7 @@ public class KernelConfigurationInternal implements KernelConfiguration
         String key = it.next();
         String value = it.next();
         logger.debug("Adding {} = {} as param to kernel", key, value);
-        kernelParamsAndAlias.put(key, value);
+        param(key, value);
     }
 
     public AliasMap kernelParams()
@@ -178,11 +180,6 @@ public class KernelConfigurationInternal implements KernelConfiguration
         return this;
     }
 
-    public List<String> getRootPackages()
-    {
-        return rootPackages;
-    }
-
     public Object getContainerContext()
     {
         return containerContext;
@@ -196,21 +193,6 @@ public class KernelConfigurationInternal implements KernelConfiguration
     public Plugin[] getPlugins()
     {
         return plugins;
-    }
-
-    public boolean isPluginScanEnabled()
-    {
-        return options.get(KernelOptions.SCAN_PLUGIN);
-    }
-
-    public DependencyInjectionMode getDependencyInjectionMode()
-    {
-        return options.get(KernelOptions.DEPENDENCY_INJECTION_MODE);
-    }
-
-    public ClasspathScanMode getClasspathScanMode()
-    {
-        return options.get(KernelOptions.CLASSPATH_SCAN_MODE);
     }
 
     public List<ModuleValidation> getValidations()

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
@@ -43,6 +43,14 @@ public class KernelConfigurationInternal implements KernelConfiguration
     private boolean isPluginScanEnabled = true;
     private Object containerContext;
     private DependencyInjectionMode dependencyInjectionMode = DependencyInjectionMode.PRODUCTION;
+    private List<String> rootPackages = new ArrayList<String>();
+
+    @Override
+    public KernelConfiguration rootPackages(String... rootPackages)
+    {
+        this.rootPackages.addAll(Arrays.asList(rootPackages));
+        return this;
+    }
 
     @Override
     public KernelConfiguration param(String key, String value)
@@ -54,7 +62,8 @@ public class KernelConfigurationInternal implements KernelConfiguration
     @Override
     public KernelConfiguration params(String... paramEntries)
     {
-        if (isNotEvenNumber(paramEntries.length)) {
+        if (isNotEvenNumber(paramEntries.length))
+        {
             throw new IllegalArgumentException("An even number of parameters was expected but found: "
                     + Arrays.toString(paramEntries));
         }
@@ -67,18 +76,21 @@ public class KernelConfigurationInternal implements KernelConfiguration
         return this;
     }
 
-    public boolean isNotEvenNumber(int number) {
+    public boolean isNotEvenNumber(int number)
+    {
         return number % 2 != 0;
     }
 
-    private void addParamKeyValue(Iterator<String> it) {
+    private void addParamKeyValue(Iterator<String> it)
+    {
         String key = it.next();
         String value = it.next();
         logger.debug("Adding {} = {} as param to kernel", key, value);
         kernelParamsAndAlias.put(key, value);
     }
 
-    public AliasMap kernelParams() {
+    public AliasMap kernelParams()
+    {
         return kernelParamsAndAlias;
     }
 
@@ -89,14 +101,17 @@ public class KernelConfigurationInternal implements KernelConfiguration
         return this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public KernelConfiguration addPlugin(Class<? extends Plugin> pluginsClass) {
+    public KernelConfiguration addPlugin(Class<? extends Plugin> pluginsClass)
+    {
         Collections.addAll(this.pluginsClass, pluginsClass);
         return this;
     }
 
     @Override
-    public KernelConfiguration plugins(Class<? extends Plugin>... pluginsClasses) {
+    public KernelConfiguration plugins(Class<? extends Plugin>... pluginsClasses)
+    {
         Collections.addAll(this.pluginsClass, pluginsClasses);
         return this;
     }
@@ -153,31 +168,43 @@ public class KernelConfigurationInternal implements KernelConfiguration
         return this;
     }
 
-    public Object getContainerContext() {
+    public List<String> getRootPackages()
+    {
+        return rootPackages;
+    }
+
+    public Object getContainerContext()
+    {
         return containerContext;
     }
 
-    public List<Class<? extends Plugin>> getPluginClasses() {
+    public List<Class<? extends Plugin>> getPluginClasses()
+    {
         return pluginsClass;
     }
 
-    public Plugin[] getPlugins() {
+    public Plugin[] getPlugins()
+    {
         return plugins;
     }
 
-    public boolean isPluginScanEnabled() {
+    public boolean isPluginScanEnabled()
+    {
         return isPluginScanEnabled;
     }
 
-    public DependencyInjectionMode getDependencyInjectionMode() {
+    public DependencyInjectionMode getDependencyInjectionMode()
+    {
         return dependencyInjectionMode;
     }
 
-    public ClasspathScanMode getClasspathScanMode() {
+    public ClasspathScanMode getClasspathScanMode()
+    {
         return classpathScanMode;
     }
 
-    public List<ModuleValidation> getValidations() {
+    public List<ModuleValidation> getValidations()
+    {
         return validations;
     }
 }

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
+ * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
  *
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version
@@ -25,6 +25,7 @@ import com.google.inject.util.Modules;
 import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.config.DependencyInjectionMode;
+import io.nuun.kernel.api.config.KernelOptions;
 import io.nuun.kernel.api.di.GlobalModule;
 import io.nuun.kernel.api.di.ObjectGraph;
 import io.nuun.kernel.api.di.UnitModule;
@@ -196,10 +197,15 @@ public final class KernelCore implements Kernel
             requestHandler.addRootPackage(rootPackage);
         }
 
-        if (kernelConfig.kernelParams().containsKey(NUUN_ROOT_PACKAGE))
+        if (kernelConfig.kernelParams().containsKey("nuun.root.package"))
         {
-            String rootPackages = kernelConfig.kernelParams().get(NUUN_ROOT_PACKAGE);
+            String rootPackages = kernelConfig.kernelParams().get("nuun.root.package");
             addPackageRootsToRequestHandler(rootPackages);
+        }
+
+        for (String rootPackage : kernelConfig.options().get(KernelOptions.ROOT_PACKAGES))
+        {
+            requestHandler.addRootPackage(rootPackage);
         }
     }
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -113,6 +113,7 @@ public final class KernelCore implements Kernel
             addAliasesToKernelParams(plugin);
             fetchGlobalParametersFrom(plugin);
             addPackageRootsToRequestHandler(plugin.pluginPackageRoot());
+            addPackageRootsToRequestHandler(plugin.rootPackages());
         }
 
         sortPlugins(facetRegistry);

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -191,6 +191,11 @@ public final class KernelCore implements Kernel
 
     private void fetchPackageRootsFromConfiguration()
     {
+        for (String rootPackage : kernelConfig.getRootPackages())
+        {
+            requestHandler.addRootPackage(rootPackage);
+        }
+
         if (kernelConfig.kernelParams().containsKey(NUUN_ROOT_PACKAGE))
         {
             String rootPackages = kernelConfig.kernelParams().get(NUUN_ROOT_PACKAGE);
@@ -205,7 +210,7 @@ public final class KernelCore implements Kernel
             for (String pack : pluginPackageRoots.split(","))
             {
                 logger.info("Adding {} as package root", pack);
-                requestHandler.addPackageRoot(pack.trim());
+                requestHandler.addRootPackage(pack.trim());
             }
         }
     }

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
@@ -17,21 +17,25 @@ import static io.nuun.kernel.core.internal.utils.NuunReflectionUtils.instantiate
  */
 class PluginRegistry
 {
-    public static final String NAME_UNIQUENESS_ERROR = "The kernel contains two plugins with the same name (%s): %s, %s";
-    public static final String TYPE_UNIQUENESS_ERROR = "The kernel contains two plugins of type ";
-    public static final String NAME_VALIDATION_ERROR = "The plugin %s doesn't have a correct name. It should not be null or empty.";
+    private static final String NAME_UNIQUENESS_ERROR = "The kernel contains two plugins with the same name (%s): %s, %s";
+    private static final String TYPE_UNIQUENESS_ERROR = "The kernel contains two plugins of type ";
+    private static final String NAME_VALIDATION_ERROR = "The plugin %s doesn't have a correct name. It should not be null or empty.";
 
     private final Map<Class<? extends Plugin>, Plugin> pluginsByClass = new HashMap<Class<? extends Plugin>, Plugin>();
     private final Map<String, Plugin> pluginsByName = new HashMap<String, Plugin>();
 
     void add(Class<? extends Plugin> pluginClass)
     {
-        Plugin plugin = instantiateSilently(pluginClass);
-        if (plugin == null)
+        try
+        {
+            add(pluginClass.newInstance());
+        } catch (InstantiationException e)
+        {
+            throw new KernelException("Plugin %s can not be instantiated", pluginClass);
+        } catch (IllegalAccessException e)
         {
             throw new KernelException("Plugin %s can not be instantiated", pluginClass);
         }
-        add(plugin);
     }
 
     /**

--- a/core/src/main/java/io/nuun/kernel/core/internal/RequestHandler.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/RequestHandler.java
@@ -35,6 +35,26 @@ import static java.util.Collections.unmodifiableMap;
  */
 public class RequestHandler extends ScanResults
 {
+    private static final String SCAN_WHOLE_CLASSPATH_WARN_MESSAGE = "\n================================ WARNING ================================\n" +
+            "   You're actually scanning the WHOLE classpath , this can be time consuming.\n" +
+            "   Please update your application configuration, to narrow the scan to your application.\n" +
+            "\n" +
+            " 1) You can update /nuun.conf in the classpath with the following content\n" +
+            "\n" +
+            "          rootPackage = com.acme1, com.acme2\n" +
+            "\n" +
+            "   where com.acme1 and com.acme2 are your root packages.\n" +
+            "\n" +
+            " 2) You can programmatically use KernelConfiguration.rootPackage(\"com.acme1\" , \"com.acme2\")\n" +
+            "\n" +
+            "   Same as above\n" +
+            "\n" +
+            " 3) You can programmatically use KernelConfiguration.param(\"scan.warn.disable\" , \"true\")\n" +
+            "\n" +
+            "   This will disable the warning. It implies, you know what you are doing.\n" +
+            "\n" +
+            "========================================================================";
+
     private final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private final List<String> propertiesPrefix = new ArrayList<String>();
@@ -201,6 +221,9 @@ public class RequestHandler extends ScanResults
 
     private void initScanner()
     {
+        if (packageRoots.isEmpty()) {
+            logger.warn(SCAN_WHOLE_CLASSPATH_WARN_MESSAGE);
+        }
         String[] packageRootArray = new String[packageRoots.size()];
         packageRoots.toArray(packageRootArray);
 
@@ -417,7 +440,7 @@ public class RequestHandler extends ScanResults
         propertiesPrefix.add(prefix);
     }
 
-    public void addPackageRoot(String root)
+    public void addRootPackage(String root)
     {
         packageRoots.add(root);
     }

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
@@ -48,29 +48,21 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
 
     public ClasspathScannerDisk(ClasspathStrategy classpathStrategy, String... packageRoots)
     {
-        this(classpathStrategy, true, null, packageRoots);
+        this(classpathStrategy, true, packageRoots);
     }
 
-    public ClasspathScannerDisk(ClasspathStrategy classpathStrategy, boolean reachAbstractClass, String packageRoot, String... packageRoots)
+    public ClasspathScannerDisk(ClasspathStrategy classpathStrategy, boolean reachAbstractClass, String... packageRoots)
     {
         super(reachAbstractClass);
         this.packageRoots = new LinkedList<String>();
-
-        if (packageRoot != null)
-        {
-            this.packageRoots.add(packageRoot);
-        }
-
         Collections.addAll(this.packageRoots, packageRoots);
-
         this.classpathStrategy = classpathStrategy;
-
         initializeReflections();
     }
 
     protected void initializeReflections()
     {
-        ConfigurationBuilder configurationBuilder = configurationBuilder().addUrls(computeUrls()).setScanners(getScanners());
+        ConfigurationBuilder configurationBuilder = configurationBuilder().addUrls(findClasspathUrls()).setScanners(getScanners());
         reflections = new Reflections(configurationBuilder);
     }
 
@@ -89,7 +81,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
         return cb;
     }
 
-    private Set<URL> computeUrls()
+    private Set<URL> findClasspathUrls()
     {
         if (urls == null)
         {

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite6Test.java
@@ -37,6 +37,7 @@ public class KernelSuite6Test
         try
         {
             underTest = createKernel(newKernelConfiguration()
+                    .rootPackages("io.nuun.kernel")
                     .withoutSpiPluginsLoader()
                     .plugins(new DummyPlugin6_A(), new DummyPlugin6_B(), new DummyPlugin6_D()));
             underTest.init();
@@ -56,6 +57,7 @@ public class KernelSuite6Test
         DummyPlugin6_D pluginD = new DummyPlugin6_D();
 
         underTest = createKernel(newKernelConfiguration()
+                .rootPackages("io.nuun.kernel")
                 .withoutSpiPluginsLoader()
                 .plugins(pluginA, pluginB, pluginC, pluginD));
 

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite7Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite7Test.java
@@ -41,6 +41,7 @@ public class KernelSuite7Test
         underTest = createKernel(
 
                 newKernelConfiguration()
+                        .rootPackages("io.nuun.kernel")
                         .withoutSpiPluginsLoader()
                         .plugins(
                                 new DummyPlugin7_A(),
@@ -62,6 +63,7 @@ public class KernelSuite7Test
         underTest = createKernel(
 
                 newKernelConfiguration()
+                        .rootPackages("io.nuun.kernel")
                         .withoutSpiPluginsLoader()
                         .plugins(
                                 new DummyPlugin7_A(),

--- a/core/src/test/java/io/nuun/kernel/core/KernelSuite8Test.java
+++ b/core/src/test/java/io/nuun/kernel/core/KernelSuite8Test.java
@@ -52,6 +52,7 @@ public class KernelSuite8Test
         Kernel underTest = createKernel(
 
                 newKernelConfiguration()
+                        .rootPackages("io.nuun.kernel")
                         .classpathScanMode(ClasspathScanMode.IN_MEMORY)
                         .withoutSpiPluginsLoader()
                         .plugins(new DummyPlugin5())

--- a/core/src/test/java/io/nuun/kernel/core/internal/Fixture.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/Fixture.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.nuun.kernel.core.internal;
+
+import com.google.common.collect.Lists;
+import io.nuun.kernel.api.Kernel;
+import io.nuun.kernel.api.config.KernelConfiguration;
+import io.nuun.kernel.api.config.KernelOptions;
+import io.nuun.kernel.core.NuunCore;
+
+public class Fixture
+{
+    public static KernelConfiguration config() {
+        return NuunCore.newKernelConfiguration()
+                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("io.nuun.kernel"))
+                .option(KernelOptions.SCAN_PLUGIN, false);
+    }
+
+    public static KernelConfiguration configWithScan() {
+        return NuunCore.newKernelConfiguration()
+                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("io.nuun.kernel"));
+    }
+
+    public static Kernel startKernel(KernelConfiguration kernelConfiguration) {
+        Kernel kernel = NuunCore.createKernel(kernelConfiguration);
+        kernel.init();
+        kernel.start();
+        return kernel;
+    }
+
+    public static Kernel initKernel(KernelConfiguration kernelConfiguration) {
+        Kernel kernel = NuunCore.createKernel(kernelConfiguration);
+        kernel.init();
+        return kernel;
+    }
+}

--- a/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
@@ -16,7 +16,7 @@
  */
 package io.nuun.kernel.core.internal;
 
-import io.nuun.kernel.api.config.ClasspathScanMode;
+import io.nuun.kernel.api.config.KernelOptions;
 import io.nuun.kernel.core.internal.concerns.ConcernTest;
 import io.nuun.kernel.core.internal.concerns.sample.BugPlugin;
 import io.nuun.kernel.core.internal.concerns.sample.CachePlugin;
@@ -24,11 +24,12 @@ import io.nuun.kernel.core.internal.concerns.sample.LogPlugin;
 import io.nuun.kernel.core.internal.concerns.sample.SecurityPlugin;
 import io.nuun.kernel.core.internal.injection.ClassInstaller;
 import io.nuun.kernel.core.internal.injection.KernelGuiceModuleInternal;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InternalKernelModuleTest
 {
@@ -37,17 +38,17 @@ public class InternalKernelModuleTest
     @Before
     public void init()
     {
-        RequestHandler requestHandler = new RequestHandler(new HashMap<String, String>(), ClasspathScanMode.NOMINAL);
+        RequestHandler requestHandler = new RequestHandler(new HashMap<String, String>(), new KernelOptions());
         underTest = new KernelGuiceModuleInternal(requestHandler);
     }
 
     @Test
     public void computeOrder_should_works()
     {
-        Assertions.assertThat(new ClassInstaller(SecurityPlugin.Module.class).order()).isEqualTo(12884901888L);
-        Assertions.assertThat(new ClassInstaller(LogPlugin.Module.class).order()).isEqualTo(-4294967296L);
-        Assertions.assertThat(new ClassInstaller(CachePlugin.Module.class).order()).isEqualTo(12884901886L);
-        Assertions.assertThat(new ClassInstaller(ConcernTest.Module.class).order()).isEqualTo(0);
-        Assertions.assertThat(new ClassInstaller(BugPlugin.Module.class).order()).isEqualTo(15032385535L);
+        assertThat(new ClassInstaller(SecurityPlugin.Module.class).order()).isEqualTo(12884901888L);
+        assertThat(new ClassInstaller(LogPlugin.Module.class).order()).isEqualTo(-4294967296L);
+        assertThat(new ClassInstaller(CachePlugin.Module.class).order()).isEqualTo(12884901886L);
+        assertThat(new ClassInstaller(ConcernTest.Module.class).order()).isEqualTo(0);
+        assertThat(new ClassInstaller(BugPlugin.Module.class).order()).isEqualTo(15032385535L);
     }
 }

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelConfigurationTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelConfigurationTest.java
@@ -1,6 +1,26 @@
+/**
+ * Copyright (C) 2013-2016 Kametic <epo.jemba@kametic.com>
+ *
+ * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
+ * or any later version
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.nuun.kernel.core.internal;
 
 import com.google.common.collect.Lists;
+import io.nuun.kernel.api.config.ClasspathScanMode;
+import io.nuun.kernel.api.config.DependencyInjectionMode;
+import io.nuun.kernel.api.config.KernelOptions;
+import io.nuun.kernel.core.NuunCore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,18 +29,36 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Pierre THIROUIN (pierre.thirouin@ext.inetpsa.com)
  */
-public class KernelConfigurationTest {
+public class KernelConfigurationTest
+{
 
     private KernelConfigurationInternal underTest = new KernelConfigurationInternal();
 
     @Test
-    public void testEmptyParamsNotNull() throws Exception {
+    public void testConfigurationOptions() throws Exception
+    {
+        KernelConfigurationInternal config = (KernelConfigurationInternal) NuunCore.newKernelConfiguration()
+                .option(KernelOptions.ENABLE_REFLECTION_LOGGER, true)
+                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("io.nuun", "org.seedstack"))
+                .option(KernelOptions.CLASSPATH_SCAN_MODE, ClasspathScanMode.IN_MEMORY);
+
+        KernelOptions options = config.options();
+        assertThat(options.get(KernelOptions.ENABLE_REFLECTION_LOGGER)).isTrue();
+        assertThat(options.get(KernelOptions.ROOT_PACKAGES)).containsOnly("io.nuun", "org.seedstack");
+        assertThat(options.get(KernelOptions.CLASSPATH_SCAN_MODE)).isEqualTo(ClasspathScanMode.IN_MEMORY);
+        assertThat(options.get(KernelOptions.DEPENDENCY_INJECTION_MODE)).isEqualTo(DependencyInjectionMode.PRODUCTION);
+    }
+
+    @Test
+    public void testEmptyParamsNotNull() throws Exception
+    {
         AliasMap params = underTest.kernelParams();
         assertThat(params).isNotNull();
     }
 
     @Test
-    public void testNullParams() throws Exception {
+    public void testNullParams() throws Exception
+    {
         underTest.param("key1", null);
         underTest.param("key2", null);
         AliasMap params = underTest.kernelParams();
@@ -29,17 +67,21 @@ public class KernelConfigurationTest {
     }
 
     @Test
-    public void testMissingParamValue() throws Exception {
-        try {
+    public void testMissingParamValue() throws Exception
+    {
+        try
+        {
             underTest.params("key1");
             fail("Expected an IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e)
+        {
             assertThat(e).hasMessage("An even number of parameters was expected but found: " + Lists.newArrayList("key1").toString());
         }
     }
 
     @Test
-    public void testParams() throws Exception {
+    public void testParams() throws Exception
+    {
         underTest.params("key1", "val1", "key2", "val2");
         AliasMap params = underTest.kernelParams();
         assertThat(params.get("key1")).isEqualTo("val1");
@@ -47,16 +89,18 @@ public class KernelConfigurationTest {
     }
 
     @Test
-    public void testParam() throws Exception {
+    public void testParam() throws Exception
+    {
         underTest.param("key1", "val1");
-        underTest.param( "key2", "val2");
+        underTest.param("key2", "val2");
         AliasMap params = underTest.kernelParams();
         assertThat(params.get("key1")).isEqualTo("val1");
         assertThat(params.get("key2")).isEqualTo("val2");
     }
 
     @Test
-    public void testParamAreNotReset() throws Exception {
+    public void testParamAreNotReset() throws Exception
+    {
         underTest.param("key1", "val1");
         AliasMap params = underTest.kernelParams();
         assertThat(params.get("key1")).isEqualTo("val1");

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginRegistryTest.java
@@ -3,6 +3,7 @@ package io.nuun.kernel.core.internal;
 import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.core.AbstractPlugin;
 import io.nuun.kernel.core.KernelException;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -83,6 +84,7 @@ public class PluginRegistryTest
         try
         {
             underTest.add(MyPlugin2.class);
+            Assertions.failBecauseExceptionWasNotThrown(KernelException.class);
         } catch (KernelException e)
         {
             assertThat(e).hasMessage(String.format("Plugin %s can not be instantiated", MyPlugin2.class));

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (C) 2013-2014 Kametic <epo.jemba@kametic.com>
- *
+ * <p/>
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.gnu.org/licenses/lgpl-3.0.txt
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,10 +16,12 @@
  */
 package io.nuun.kernel.core.internal.concerns;
 
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.config.KernelConfiguration;
+import io.nuun.kernel.api.config.KernelOptions;
 import io.nuun.kernel.core.AbstractPlugin;
 import io.nuun.kernel.core.NuunCore;
 import io.nuun.kernel.core.internal.concerns.sample.CachePlugin;
@@ -38,71 +40,75 @@ public class ConcernTest
 
     static Kernel underTest;
     private static List<String> list;
-    
+
     @BeforeClass
     public static void init()
     {
         list = new ArrayList<String>();
-        
+
         KernelConfiguration newKernelConfiguration = NuunCore.newKernelConfiguration();
-        newKernelConfiguration.withoutSpiPluginsLoader().plugins(new InternalPlugin() , new CachePlugin(list ) , new LogPlugin(list) , new SecurityPlugin(list));
-        
+        newKernelConfiguration
+                .option(KernelOptions.SCAN_PLUGIN, false)
+                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("io.nuun.kernel"))
+                .plugins(new InternalPlugin(), new CachePlugin(list), new LogPlugin(list), new SecurityPlugin(list));
+
         underTest = NuunCore.createKernel(newKernelConfiguration);
         underTest.init();
         underTest.start();
     }
-    
+
     static class MyObj
     {
-        
+
         void triggerMethod(List<String> list)
         {
             list.add("fire");
         }
     }
-    
+
     public static class InternalPlugin extends AbstractPlugin
     {
-        
-    	@Override
-    	public String name ()
-    	{
-    		return "nominal plugin";
-    	}
 
-    	@Override
+        @Override
+        public String name()
+        {
+            return "nominal plugin";
+        }
+
+        @Override
         public Object nativeUnitModule()
         {
             return new Module();
         }
     }
-    
+
     public static class Module extends AbstractModule
     {
-        
+
         @Override
         protected void configure()
         {
             bind(MyObj.class);
         }
     }
-    
+
     @Test
     public void test()
     {
-        
+
         MyObj obj = underTest.objectGraph().as(Injector.class).getInstance(MyObj.class);
         obj.triggerMethod(list);
         Assertions.assertThat(list).hasSize(7);
-        Assertions.assertThat(list).containsExactly("pre security" , "pre cache" , "pre log", "fire" , "post log",  "post cache"  ,  "post security");
+        Assertions.assertThat(list).containsExactly("pre security", "pre cache", "pre log", "fire", "post log", "post cache", "post security");
     }
-    
+
     @AfterClass
     public static void clear()
     {
-        if ( underTest.isStarted()) {
-			underTest.stop();
-		}
+        if (underTest.isStarted())
+        {
+            underTest.stop();
+        }
     }
 
 }

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
@@ -16,14 +16,11 @@
  */
 package io.nuun.kernel.core.internal.concerns;
 
-import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Injector;
 import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.api.config.KernelConfiguration;
-import io.nuun.kernel.api.config.KernelOptions;
 import io.nuun.kernel.core.AbstractPlugin;
-import io.nuun.kernel.core.NuunCore;
+import io.nuun.kernel.core.internal.Fixture;
 import io.nuun.kernel.core.internal.concerns.sample.CachePlugin;
 import io.nuun.kernel.core.internal.concerns.sample.LogPlugin;
 import io.nuun.kernel.core.internal.concerns.sample.SecurityPlugin;
@@ -45,16 +42,14 @@ public class ConcernTest
     public static void init()
     {
         list = new ArrayList<String>();
-
-        KernelConfiguration newKernelConfiguration = NuunCore.newKernelConfiguration();
-        newKernelConfiguration
-                .option(KernelOptions.SCAN_PLUGIN, false)
-                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("io.nuun.kernel"))
-                .plugins(new InternalPlugin(), new CachePlugin(list), new LogPlugin(list), new SecurityPlugin(list));
-
-        underTest = NuunCore.createKernel(newKernelConfiguration);
-        underTest.init();
-        underTest.start();
+        underTest = Fixture.startKernel(Fixture.config()
+                .plugins(
+                        new InternalPlugin(),
+                        new CachePlugin(list),
+                        new LogPlugin(list),
+                        new SecurityPlugin(list)
+                )
+        );
     }
 
     static class MyObj

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerTestBase.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/ClasspathScannerTestBase.java
@@ -76,8 +76,8 @@ public abstract class ClasspathScannerTestBase
         Collection<Class<?>> scanClasspathSubType = underTest.scanTypesAnnotatedBy(KernelModule.class);
 
         assertThat(scanClasspathSubType).isNotNull();
-        assertThat(scanClasspathSubType).hasSize(3);
-        assertThat(scanClasspathSubType).containsOnly(MyModule1.class, Module7.class, MyModule4.class);
+        assertThat(scanClasspathSubType).hasSize(2);
+        assertThat(scanClasspathSubType).containsOnly(MyModule1.class, MyModule4.class);
     }
     
     

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemoryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemoryTest.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
- *
+ * <p/>
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.gnu.org/licenses/lgpl-3.0.txt
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,38 +32,29 @@ import static io.nuun.kernel.api.inmemory.ClasspathResource.res;
 public class ClasspathScannerInMemoryTest extends ClasspathScannerTestBase
 {
 
-	private InMemoryMultiThreadClasspath classpath = InMemoryMultiThreadClasspath.INSTANCE;
-	
-	@SuppressWarnings("unchecked")
-	@Override
-	protected AbstractClasspathScanner createUnderTest() {
-		
+    private InMemoryMultiThreadClasspath classpath = InMemoryMultiThreadClasspath.INSTANCE;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected AbstractClasspathScanner createUnderTest()
+    {
         classpath.reset();
         classpath
-         .add (
-        		 ClasspathDirectory.create ("default")
-        		 
-	                 .add(res("META-INF/properties", "tst-one.properties"))
-	                 .add(res("META-INF/properties", "tst-two.properties"))
-        		 )
-         .add (
-        		 ClasspathJar.create ("app.jar")
-        		 
-	        		 .add(new ClasspathClass(Bean1.class))
-	        		 .add(new ClasspathClass(Bean2.class))
-	        		 .add(new ClasspathClass(Bean3.class))
-	        		 .add(new ClasspathClass(Bean6.class))
-        		 
-        		 )
-         .add (
-        		 ClasspathJar.create ("modules.jar")
-        		 
-	        		 .add(new ClasspathClass(MyModule1.class))
-	        		 .add(new ClasspathClass(MyModule4.class))
-	        		 .add(new ClasspathClass(Module7.class))
-        		 
-        		 );
+                .add(ClasspathDirectory.create("default")
+                        .add(res("META-INF/properties", "tst-one.properties"))
+                        .add(res("META-INF/properties", "tst-two.properties"))
+                )
+                .add(ClasspathJar.create("app.jar")
+                        .add(new ClasspathClass(Bean1.class))
+                        .add(new ClasspathClass(Bean2.class))
+                        .add(new ClasspathClass(Bean3.class))
+                        .add(new ClasspathClass(Bean6.class))
+                )
+                .add(ClasspathJar.create("modules.jar")
+                        .add(new ClasspathClass(MyModule1.class))
+                        .add(new ClasspathClass(MyModule4.class))
+                );
 
         return new ClasspathScannerInMemory(classpath);
-	}
+    }
 }

--- a/core/src/test/java/io/nuun/kernel/core/internal/scanner/reflections/ClasspathScannerReflectionsTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/scanner/reflections/ClasspathScannerReflectionsTest.java
@@ -28,7 +28,7 @@ public class ClasspathScannerReflectionsTest extends ClasspathScannerTestBase
     
     @Override
     protected AbstractClasspathScanner createUnderTest() {
-    	return new ClasspathScannerDisk(new ClasspathStrategy(), true, "", "META-INF.properties," + MyModule2.class.getPackage().getName());
+    	return new ClasspathScannerDisk(new ClasspathStrategy(), true, "META-INF.properties", MyModule2.class.getPackage().getName());
     }
  
 }

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
@@ -21,7 +21,6 @@ package io.nuun.kernel.core.pluginsit.dummy1;
 
 import com.google.common.collect.Lists;
 import com.google.inject.Module;
-import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
@@ -89,7 +88,7 @@ public class DummyPlugin extends AbstractPlugin
         assertThat(param).isNotEmpty();
         assertThat(param).isEqualTo("WAZAAAA");
 
-        String param2 = initContext.kernelParam(Kernel.NUUN_ROOT_PACKAGE);
+        String param2 = initContext.kernelParam("nuun.root.package");
         assertThat(param2).isNotNull();
         assertThat(param2).isEqualTo("internal," + KernelCoreIT.class.getPackage().getName());
 
@@ -170,7 +169,7 @@ public class DummyPlugin extends AbstractPlugin
     public Map<String, String> kernelParametersAliases()
     {
         Map<String, String> m = new HashMap<String, String>();
-        m.put(NUUN_ROOT_ALIAS, Kernel.NUUN_ROOT_PACKAGE);
+        m.put(NUUN_ROOT_ALIAS, "nuun.root.package");
         m.put(ALIAS_DUMMY_PLUGIN1, "dummy.plugin1");
         return m;
     }

--- a/core/src/test/java/it/AliasIT.java
+++ b/core/src/test/java/it/AliasIT.java
@@ -1,12 +1,11 @@
 package it;
 
 import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.api.config.KernelConfiguration;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
 import io.nuun.kernel.core.AbstractPlugin;
-import io.nuun.kernel.core.NuunCore;
+import io.nuun.kernel.core.internal.Fixture;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -22,16 +21,12 @@ public class AliasIT
     @Test
     public void testAliases() throws Exception
     {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
+        Kernel kernel = Fixture.startKernel(Fixture.config()
                 .param("alias1", "val1")
                 .param("alias2", "val2")
                 .addPlugin(AliasProviderPlugin.class)
-                .addPlugin(AliasUserPlugin.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
-        kernel.start();
+                .addPlugin(AliasUserPlugin.class)
+        );
 
         AliasProviderPlugin aliasProvider = (AliasProviderPlugin) kernel.plugins().get("alias-provider");
         Assertions.assertThat(aliasProvider.param1).isEqualTo("val1");

--- a/core/src/test/java/it/ClasspathScanningIT.java
+++ b/core/src/test/java/it/ClasspathScanningIT.java
@@ -1,7 +1,9 @@
 package it;
 
+import com.google.common.collect.Lists;
 import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.api.config.KernelConfiguration;
+import io.nuun.kernel.api.config.KernelOptions;
 import io.nuun.kernel.core.NuunCore;
 import it.fixture.scan.ClassToScan1;
 import it.fixture.scan.ClassToScan2;
@@ -23,8 +25,8 @@ public class ClasspathScanningIT {
     @Test
     public void test_class_scan_and_ignored_policy() {
         KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
-                .param(Kernel.NUUN_ROOT_PACKAGE, "it.fixture.scan")
+                .option(KernelOptions.SCAN_PLUGIN, false)
+                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("it.fixture.scan"))
                 .addPlugin(ScanningPlugin.class);
 
         Kernel kernel = NuunCore.createKernel(kernelConfig);

--- a/core/src/test/java/it/MainInjectorIT.java
+++ b/core/src/test/java/it/MainInjectorIT.java
@@ -2,11 +2,11 @@ package it;
 
 import com.google.inject.Injector;
 import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.api.config.KernelConfiguration;
-import io.nuun.kernel.core.NuunCore;
+import io.nuun.kernel.core.internal.Fixture;
 import it.fixture.injection.*;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the main injector built by the kernel.
@@ -20,22 +20,18 @@ public class MainInjectorIT {
      */
     @Test
     public void test_main_injector() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
+        Kernel kernel = Fixture.startKernel(Fixture.config()
                 .addPlugin(InjectionPlugin1.class)
-                .addPlugin(InjectionPlugin2.class);
+                .addPlugin(InjectionPlugin2.class));
 
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
-        kernel.start();
         Injector injector = kernel.objectGraph().as(Injector.class);
 
         InjectableInterface1 injectableInterface1 = injector.getInstance(InjectableInterface1.class);
-        Assertions.assertThat(injectableInterface1).isNotNull();
-        Assertions.assertThat(injectableInterface1).isInstanceOf(InjecteeImplementation1.class);
+        assertThat(injectableInterface1).isNotNull();
+        assertThat(injectableInterface1).isInstanceOf(InjecteeImplementation1.class);
 
         InjectableInterface2 injectableInterface2 = injector.getInstance(InjectableInterface2.class);
-        Assertions.assertThat(injectableInterface2).isNotNull();
-        Assertions.assertThat(injectableInterface2).isInstanceOf(InjecteeImplementation2.class);
+        assertThat(injectableInterface2).isNotNull();
+        assertThat(injectableInterface2).isInstanceOf(InjecteeImplementation2.class);
     }
 }

--- a/core/src/test/java/it/PluginDependencyIT.java
+++ b/core/src/test/java/it/PluginDependencyIT.java
@@ -1,11 +1,11 @@
 package it;
 
-import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.api.config.KernelConfiguration;
 import io.nuun.kernel.core.KernelException;
-import io.nuun.kernel.core.NuunCore;
 import it.fixture.dependencies.*;
 import org.junit.Test;
+
+import static io.nuun.kernel.core.internal.Fixture.config;
+import static io.nuun.kernel.core.internal.Fixture.initKernel;
 
 /**
  * Tests dependencies between plugins.
@@ -19,13 +19,9 @@ public class PluginDependencyIT {
      */
     @Test
     public void test_dependent_plugin() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
+        initKernel(config()
                 .addPlugin(WithDependentDepsPlugin.class)
-                .addPlugin(DependentPlugin1.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
+                .addPlugin(DependentPlugin1.class));
     }
 
     /**
@@ -33,12 +29,7 @@ public class PluginDependencyIT {
      */
     @Test(expected = KernelException.class)
     public void test_dependent_plugin_with_missing_dependency() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
-                .addPlugin(WithDependentDepsPlugin.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
+        initKernel(config().addPlugin(WithDependentDepsPlugin.class));
     }
 
     /**
@@ -46,13 +37,9 @@ public class PluginDependencyIT {
      */
     @Test
     public void test_required_plugin() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
+        initKernel(config()
                 .addPlugin(WithRequiredDepsPlugin.class)
-                .addPlugin(RequiredPlugin1.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
+                .addPlugin(RequiredPlugin1.class));
     }
 
     /**
@@ -60,12 +47,7 @@ public class PluginDependencyIT {
      */
     @Test(expected = KernelException.class)
     public void test_required_plugin_with_missing_dependency() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
-                .addPlugin(WithRequiredDepsPlugin.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
+        initKernel(config().addPlugin(WithRequiredDepsPlugin.class));
     }
 
     /**
@@ -73,12 +55,8 @@ public class PluginDependencyIT {
      */
     @Test
     public void test_required_facet() {
-        KernelConfiguration kernelConfig = NuunCore.newKernelConfiguration()
-                .withoutSpiPluginsLoader()
+        initKernel(config()
                 .addPlugin(Facet1Plugin.class)
-                .addPlugin(WithRequiredFacetPlugin.class);
-
-        Kernel kernel = NuunCore.createKernel(kernelConfig);
-        kernel.init();
+                .addPlugin(WithRequiredFacetPlugin.class));
     }
 }

--- a/core/src/test/java/it/PluginDiscoveryIT.java
+++ b/core/src/test/java/it/PluginDiscoveryIT.java
@@ -1,11 +1,12 @@
 package it;
 
+import io.nuun.kernel.api.Kernel;
+import io.nuun.kernel.core.internal.Fixture;
 import it.fixture.NoOpPlugin1;
 import it.fixture.NoOpPlugin2;
-import io.nuun.kernel.api.Kernel;
-import io.nuun.kernel.core.NuunCore;
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class tests the SPI allowing to register Plugin using the classLoader.
@@ -19,10 +20,10 @@ public class PluginDiscoveryIT {
      */
     @Test
     public void test_plugin_discovery() {
-        Kernel kernel = NuunCore.createKernel(NuunCore.newKernelConfiguration());
-        kernel.init();
-        Assertions.assertThat(kernel.plugins()).hasSize(2);
-        Assertions.assertThat(kernel.plugins().get(NoOpPlugin1.NAME)).isInstanceOf(NoOpPlugin1.class);
-        Assertions.assertThat(kernel.plugins().get(NoOpPlugin2.NAME)).isInstanceOf(NoOpPlugin2.class);
+        Kernel kernel = Fixture.initKernel(Fixture.configWithScan());
+
+        assertThat(kernel.plugins()).hasSize(2);
+        assertThat(kernel.plugins().get(NoOpPlugin1.NAME)).isInstanceOf(NoOpPlugin1.class);
+        assertThat(kernel.plugins().get(NoOpPlugin2.NAME)).isInstanceOf(NoOpPlugin2.class);
     }
 }

--- a/specs/src/main/java/io/nuun/kernel/api/Kernel.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Kernel.java
@@ -30,9 +30,6 @@ import java.util.Map;
 public interface Kernel
 {
     String NUUN_PROPERTIES_PREFIX = "nuun-";
-    String NUUN_ROOT_PACKAGE = "nuun.root.package";
-    String NUUN_NUM_CP_PATH = "nuun.num.classpath.path";
-    String NUUN_CP_PATH_PREFIX = "nuun.classpath.path.prefix-";
     String NUUN_CP_STRATEGY_NAME = "nuun.classpath.strategy.name";
     String NUUN_CP_STRATEGY_ADD = "nuun.classpath.strategy.additional";
     String KERNEL_PREFIX_NAME = "Kernel-";

--- a/specs/src/main/java/io/nuun/kernel/api/Plugin.java
+++ b/specs/src/main/java/io/nuun/kernel/api/Plugin.java
@@ -118,7 +118,16 @@ public interface Plugin
      * 
      * @return the package roots
      */
+    @Deprecated
     String pluginPackageRoot();
+
+    /**
+     * The root package(s) use to filter the classpath scanning. It is possible
+     * to specify multiple root packages by separating them by a comma.
+     *
+     * @return the package roots
+     */
+    String rootPackages();
 
     /**
      * Return an object that will contains the dependency injection definitions. Mostly a Guice module but

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (C) 2014 Kametic <epo.jemba@kametic.com>
- *
+ * <p/>
  * Licensed under the GNU LESSER GENERAL PUBLIC LICENSE, Version 3, 29 June 2007;
  * or any later version
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p/>
  * http://www.gnu.org/licenses/lgpl-3.0.txt
- *
+ * <p/>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,7 @@ import io.nuun.kernel.api.di.ModuleValidation;
  */
 public interface KernelConfiguration
 {
+    <T> KernelConfiguration option(KernelOption<T> option, T value);
 
     /**
      * Sets the root packages. By default if no root package is set the scanner will scan all the classpath.
@@ -134,5 +135,5 @@ public interface KernelConfiguration
      * @return itself
      */
     KernelConfiguration moduleValidation(ModuleValidation validation);
-    
+
 }

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelConfiguration.java
@@ -26,6 +26,14 @@ public interface KernelConfiguration
 {
 
     /**
+     * Sets the root packages. By default if no root package is set the scanner will scan all the classpath.
+     *
+     * @param rootPackages the list of packages to scan
+     * @return itself
+     */
+    KernelConfiguration rootPackages(String... rootPackages);
+
+    /**
      * Sets a key/value parameter.
      *
      * @param key the key

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelOption.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelOption.java
@@ -1,0 +1,37 @@
+package io.nuun.kernel.api.config;
+
+
+import javax.annotation.Nullable;
+
+public class KernelOption<T>
+{
+    private String name;
+    private T value;
+
+    public KernelOption(String name) {
+        this.name = name;
+    }
+
+    public KernelOption(String name, T value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public KernelOption(KernelOption<T> option, @Nullable T value) {
+        this.name = option.name;
+        this.value = value == null ? option.getValue() : value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return name + ": " + value;
+    }
+}

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
@@ -1,0 +1,56 @@
+package io.nuun.kernel.api.config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KernelOptions
+{
+    public static final KernelOption<List<String>> ROOT_PACKAGES = new KernelOption<List<String>>("root.packages");
+    public static final KernelOption<Boolean> PRINT_SCAN_WARN = new KernelOption<Boolean>("scan.warn.disable");
+    public static final KernelOption<Boolean> ENABLE_REFLECTION_LOGGER = new KernelOption<Boolean>("reflection.logger.disable");
+    public static final KernelOption<Boolean> SCAN_PLUGIN = new KernelOption<Boolean>("plugin.scan.disable");
+    public static final KernelOption<ClasspathScanMode> CLASSPATH_SCAN_MODE = new KernelOption<ClasspathScanMode>("classpath.scan.mode");
+    public static final KernelOption<DependencyInjectionMode> DEPENDENCY_INJECTION_MODE = new KernelOption<DependencyInjectionMode>("dependency.injection.mode");
+
+    private final Map<String, Object> options = new HashMap<String, Object>();
+
+    public KernelOptions()
+    {
+        set(ROOT_PACKAGES, new ArrayList<String>());
+        set(PRINT_SCAN_WARN, true);
+        set(ENABLE_REFLECTION_LOGGER, false);
+        set(SCAN_PLUGIN, true);
+        set(CLASSPATH_SCAN_MODE, ClasspathScanMode.NOMINAL);
+        set(DEPENDENCY_INJECTION_MODE, DependencyInjectionMode.PRODUCTION);
+    }
+
+    public <T> KernelOptions set(KernelOption<T> option, T value)
+    {
+        options.put(option.getName(), value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T get(KernelOption<T> option)
+    {
+        return (T) options.get(option.getName());
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Map.Entry<String, Object> entry : options.entrySet())
+        {
+            stringBuilder.append(entry.getKey()).append(": ");
+            if (entry.getValue() != null)
+            {
+                stringBuilder.append(entry.getValue().toString());
+            }
+            stringBuilder.append("\n");
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/tests/src/test/java/io/nuun/kernel/tests/it/NuunITRunnerTest.java
+++ b/tests/src/test/java/io/nuun/kernel/tests/it/NuunITRunnerTest.java
@@ -17,7 +17,6 @@
 package io.nuun.kernel.tests.it;
 
 import com.google.inject.Inject;
-import io.nuun.kernel.api.Kernel;
 import io.nuun.kernel.tests.it.annotations.WithParams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author epo.jemba{@literal @}kametic.com
  *
  */
-@WithParams({Kernel.NUUN_ROOT_PACKAGE, "io.nuun.kernel.tests"})
+@WithParams({"nuun.root.package", "io.nuun.kernel.tests"})
 @RunWith(NuunITRunner.class)
 public class NuunITRunnerTest
 {


### PR DESCRIPTION
Currently I find difficult to know what are the configuration options for the kernel. Some of them are accessible via KernelConfiguration, some of them are accessible through kernel params and it's also difficult to find all the kernel params.

So I propose an option system à la XNIO ([javadoc](http://docs.jboss.org/xnio/3.0.4.GA/api/org/xnio/Options.html)).

Add a typed option:
```
public class KernelOption<T>
{
    private String name;
    private T value;
}
```

Group all the options in a class `KernelOptions`:
```
public class KernelOptions
{
    public static final KernelOption<List<String>> ROOT_PACKAGES = new KernelOption<List<String>>("root.packages");
    public static final KernelOption<Boolean> PRINT_SCAN_WARN = new KernelOption<Boolean>("scan.warn.disable");
    ...
}
```

Add an option method  on `KernelConfiguration`: 

    <T> KernelConfiguration option(KernelOption<T> option, T value)

Then use it as follows:
```
NuunCore.newKernelConfiguration()
                .option(KernelOptions.SCAN_PLUGIN, false)
                .option(KernelOptions.ROOT_PACKAGES, Lists.newArrayList("it.fixture.scan"))
```

As a bonus this PR also add a fixture to factorize the kernel creation in the tests.