### PR TITLE
Exclude poms from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,10 @@
                     <useDefaultExcludes>true</useDefaultExcludes>
                     <excludes>
                         <exclude>LICENSE</exclude>
+                        <exclude>NOTICE</exclude>
                         <exclude>**/*.md</exclude>
+                        <!-- Maven release plugin alters the license header of poms which leads to a failing check during release:prepare -->
+                        <exclude>**/pom.xml</exclude>
                     </excludes>
                     <skip>${license-header-check.skip}</skip>
                 </configuration>


### PR DESCRIPTION
The maven release plugin is (again) doing funny things to the poms during release, leading to a failing license check for pom files. More specifically it adds a space to the link to the GNU website. 

I just excluded the poms from the license check (but they still contain the correct license header). Long-term solution would be to get rid of the maven release plugin as I have done on SeedStack.