### PR TITLE
Java 8 predicates instead of specifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - openjdk6
-  - openjdk7
   - oraclejdk8
 
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 1.0.M10 (???)
+
+* [chg] The specs module is now without any dependency.
+* [brk] Class specifications have been replaced by class predicates.
+* [brk] Java 8 is now required.
+
 # Version 1.0.M8 (???)
 
 * [new] Kernel options are centralized in `KernelOptions`

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,13 +48,16 @@
 	<url>http://nuun.io/kernel/core</url>
 
 	<dependencies>
-
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.16</version>
+		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>kernel-specs</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
@@ -80,5 +83,4 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
+++ b/core/src/main/java/io/nuun/kernel/core/AbstractPlugin.java
@@ -22,28 +22,28 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.Round;
 import io.nuun.kernel.api.plugin.context.Context;
 import io.nuun.kernel.api.plugin.context.InitContext;
-import io.nuun.kernel.api.plugin.request.*;
+import io.nuun.kernel.api.plugin.request.BindingRequest;
+import io.nuun.kernel.api.plugin.request.BindingRequestBuilder;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.plugin.request.ClasspathScanRequestBuilder;
+import io.nuun.kernel.api.plugin.request.KernelParamsRequest;
+import io.nuun.kernel.api.plugin.request.KernelParamsRequestBuilder;
 import io.nuun.kernel.api.plugin.request.builders.BindingRequestBuilderMain;
 import io.nuun.kernel.core.internal.injection.ModuleEmbedded;
 import io.nuun.kernel.spi.DependencyInjectionProvider;
-import org.kametic.specifications.*;
-import org.kametic.specifications.reflect.ClassMethodsAnnotatedWith;
-import org.kametic.specifications.reflect.DescendantOfSpecification;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.net.URL;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Epo Jemba
  */
 public abstract class AbstractPlugin implements Plugin
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlugin.class);
-
     protected Context context = null;
     protected Object containerContext = null;
     protected Round round;
@@ -82,96 +82,6 @@ public abstract class AbstractPlugin implements Plugin
     protected BindingRequestBuilderMain bindingRequestsBuilder()
     {
         return new BindingRequestBuilder();
-    }
-
-    // ============================= PLUGIN Utilities Helpers =============================
-
-    protected Specification<Class<?>> or(Specification<Class<?>>... participants)
-    {
-        return new OrSpecification<Class<?>>(participants);
-    }
-
-    protected Specification<Class<?>> and(Specification<Class<?>>... participants)
-    {
-        return new AndSpecification<Class<?>>(participants);
-    }
-
-    protected Specification<Class<?>> not(Specification<Class<?>> participant)
-    {
-        return new NotSpecification<Class<?>>(participant);
-    }
-
-    protected Specification<Class<?>> descendantOf(Class<?> ancestor)
-    {
-        return new DescendantOfSpecification(ancestor);
-    }
-    
-    protected Specification<Class<?>> classMethodsAnnotatedWith(final Class<? extends Annotation> annotationClass)
-    {
-    	return new ClassMethodsAnnotatedWith(annotationClass);
-    }
-
-    protected Specification<Class<?>> fieldAnnotatedWith(final Class<? extends Annotation> annotationClass)
-    {
-    	return new AbstractSpecification<Class<?>> ()
-    	{
-    		@Override
-    		public boolean isSatisfiedBy(Class<?> candidate) {
-    			if (candidate != null)
-    			{
-    			    try
-                    {
-    			        for (Field field : candidate.getDeclaredFields())
-    			        {
-    			            if (field.isAnnotationPresent(annotationClass))
-    			            {
-    			                return true;
-    			            }
-    			        }
-                    }
-                    catch (Throwable throwable)
-                    {
-                        LOGGER.debug("fieldAnnotatedWith : " + candidate + " missing " + throwable);
-                    }
-    			}
-    			return false;
-    		}
-    	};
-    }
-
-    protected Specification<Class<?>> classAnnotatedWith(final Class<? extends Annotation> klass)
-    {
-        return new AbstractSpecification<Class<?>>()
-        {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate)
-            {
-                return candidate != null && candidate.getAnnotation(klass) != null;
-            }
-        };
-    }
-
-    // TODO replace this implementation by the one in ClassMethodsAnnotatedWithSpecification
-    protected Specification<Class<?>> classImplements(final Class<?> klass)
-    {
-        return new AbstractSpecification<Class<?>>()
-        {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate)
-            {
-                if (candidate != null && klass.isInterface())
-                {
-                    for (Class<?> i : candidate.getInterfaces())
-                    {
-                        if (i.equals(klass))
-                        {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
-        };
     }
 
     // * ============================= PLUGIN info and requests * ============================= //
@@ -295,7 +205,7 @@ public abstract class AbstractPlugin implements Plugin
     @Override
     public Map<String, String> kernelParametersAliases()
     {
-        return new HashMap<String, String>();
+        return new HashMap<>();
     }
     
     protected UnitModule unitModule(Object module)

--- a/core/src/main/java/io/nuun/kernel/core/internal/AliasMap.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/AliasMap.java
@@ -25,8 +25,8 @@ import java.util.*;
  */
 public class AliasMap
 {
-    private Map<String, String> aliases = new HashMap<String, String>();
-    private Map<String, String> params = new HashMap<String, String>();
+    private Map<String, String> aliases = new HashMap<>();
+    private Map<String, String> params = new HashMap<>();
 
     /**
      * @param key   the key to alias.
@@ -44,7 +44,7 @@ public class AliasMap
 
     public String get(String key)
     {
-        List<String> cache = new ArrayList<String>();
+        List<String> cache = new ArrayList<>();
         return getWithAlias(key, cache);
     }
 
@@ -72,7 +72,7 @@ public class AliasMap
 
     public Map<String, String> toMap()
     {
-        Map<String, String> map = new HashMap<String, String>(params);
+        Map<String, String> map = new HashMap<>(params);
         for (Map.Entry<String, String> entry : aliases.entrySet())
         {
             String alias = entry.getKey();

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependenciesAsserter.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependenciesAsserter.java
@@ -23,12 +23,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-class DependenciesSpecification
+class DependenciesAsserter
 {
 
     private final FacetRegistry facetRegistry;
 
-    DependenciesSpecification(FacetRegistry facetRegistry)
+    DependenciesAsserter(FacetRegistry facetRegistry)
     {
         this.facetRegistry = facetRegistry;
     }
@@ -39,9 +39,9 @@ class DependenciesSpecification
      *
      * @param plugin the plugin to check
      */
-    void isSatisfyBy(final Plugin plugin)
+    void assertDependencies(final Plugin plugin)
     {
-        Collection<Class<?>> expectedDependencies = new ArrayList<Class<?>>();
+        Collection<Class<?>> expectedDependencies = new ArrayList<>();
 
         Collection<Class<?>> requiredPlugins = plugin.requiredPlugins();
         if (requiredPlugins != null)

--- a/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/DependencyProvider.java
@@ -58,7 +58,7 @@ class DependencyProvider {
 
     private List<Plugin> getDependenciesOf(Class<? extends Plugin> pluginClass, DependencyType dependencyType) {
         Plugin plugin = pluginRegistry.get(pluginClass);
-        List<Plugin> dependencies = new ArrayList<Plugin>();
+        List<Plugin> dependencies = new ArrayList<>();
         if (plugin != null) {
             for (Class<?> requiredClass : getDependencyClasses(plugin, dependencyType)) {
                 //noinspection unchecked
@@ -69,7 +69,7 @@ class DependencyProvider {
     }
 
     private Collection<Class<?>> getDependencyClasses(Plugin plugin, DependencyType dependencyType) {
-        Collection<Class<?>> requiredClasses = new ArrayList<Class<?>>();
+        Collection<Class<?>> requiredClasses = new ArrayList<>();
         if (dependencyType == DependencyType.REQUIRED) {
             requiredClasses = plugin.requiredPlugins();
         } else if (dependencyType == DependencyType.DEPENDENT) {

--- a/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
@@ -55,7 +55,7 @@ public class ExtensionManager
     {
 
         ServiceLoader<KernelExtension> kernelExtensionLoader = ServiceLoader.load(KernelExtension.class, contextClassLoader);
-        Map<Class<?>, KernelExtension<?>> extensionMapping = new HashMap<Class<?>, KernelExtension<?>>();
+        Map<Class<?>, KernelExtension<?>> extensionMapping = new HashMap<>();
         for (KernelExtension<?> kernelExtension : kernelExtensionLoader)
         {
             Class<?> extensionInterface = TypeToken.of(kernelExtension.getClass()).resolveType(KernelExtension.class.getTypeParameters()[0]).getRawType();

--- a/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/FacetRegistry.java
@@ -32,7 +32,7 @@ import java.util.*;
 class FacetRegistry
 {
     private final ListMultimap<Class<?>, Plugin> pluginsByFacet = ArrayListMultimap.create();
-    private final Map<Class<?>, Plugin> pluginsByClass = new HashMap<Class<?>, Plugin>();
+    private final Map<Class<?>, Plugin> pluginsByClass = new HashMap<>();
 
     /**
      * Constructs a facet registry.
@@ -106,7 +106,7 @@ class FacetRegistry
     {
         if (facet != null && Plugin.class.isAssignableFrom(facet))
         {
-            List<T> ts = new ArrayList<T>();
+            List<T> ts = new ArrayList<>();
             Plugin plugin = pluginsByClass.get(facet);
             if (plugin != null)
             {

--- a/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/InitContextInternal.java
@@ -19,10 +19,12 @@ package io.nuun.kernel.core.internal;
 import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.di.UnitModule;
 import io.nuun.kernel.api.plugin.context.InitContext;
-import org.kametic.specifications.Specification;
 
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 
 public class InitContextInternal implements InitContext
 {
@@ -67,12 +69,6 @@ public class InitContextInternal implements InitContext
     }
 
     @Override
-    public Map<Class<?>, Collection<Class<?>>> scannedSubTypesByAncestorClass()
-    {
-        return requestHandler.scannedSubTypesByAncestorClass();
-    }
-
-    @Override
     public Map<String, Collection<Class<?>>> scannedSubTypesByParentRegex()
     {
         return requestHandler.scannedSubTypesByParentRegex();
@@ -85,9 +81,9 @@ public class InitContextInternal implements InitContext
     }
 
     @Override
-    public Map<Specification, Collection<Class<?>>> scannedTypesBySpecification()
+    public Map<Predicate<Class<?>>, Collection<Class<?>>> scannedTypesByPredicate()
     {
-        return requestHandler.scannedTypesBySpecification();
+        return requestHandler.scannedTypesByPredicate();
     }
 
     @Override

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelConfigurationInternal.java
@@ -34,9 +34,9 @@ public class KernelConfigurationInternal implements KernelConfiguration
     private final Logger logger = LoggerFactory.getLogger(KernelConfiguration.class);
     private final AliasMap kernelParamsAndAlias = new AliasMap();
 
-    private List<Class<? extends Plugin>> pluginsClass = new ArrayList<Class<? extends Plugin>>();
+    private List<Class<? extends Plugin>> pluginsClass = new ArrayList<>();
     private Plugin[] plugins = new Plugin[0];
-    private List<ModuleValidation> validations = new ArrayList<ModuleValidation>();
+    private List<ModuleValidation> validations = new ArrayList<>();
     private Object containerContext;
 
     private KernelOptions options = new KernelOptions();

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -109,11 +109,11 @@ public final class KernelCore implements Kernel
         dependencyProvider = new DependencyProvider(pluginRegistry, facetRegistry);
 
         round = new RoundInternal();
-        DependenciesSpecification dependenciesSpecification = new DependenciesSpecification(facetRegistry);
+        DependenciesAsserter dependenciesAsserter = new DependenciesAsserter(facetRegistry);
         for (Plugin plugin : pluginRegistry.getPlugins())
         {
             plugin.provideRound(round);
-            dependenciesSpecification.isSatisfyBy(plugin);
+            dependenciesAsserter.assertDependencies(plugin);
             addAliasesToKernelParams(plugin);
             fetchGlobalParametersFrom(plugin);
             addPackageRootsToRequestHandler(plugin.pluginPackageRoot());
@@ -191,7 +191,7 @@ public final class KernelCore implements Kernel
 
     private void sortPlugins(FacetRegistry facetRegistry)
     {
-        ArrayList<Plugin> unOrderedPlugins = new ArrayList<Plugin>(pluginRegistry.getPlugins());
+        ArrayList<Plugin> unOrderedPlugins = new ArrayList<>(pluginRegistry.getPlugins());
         logger.trace("unordered plugins: ({}) {}", unOrderedPlugins.size(), unOrderedPlugins);
         orderedPlugins = new PluginSortStrategy(facetRegistry, unOrderedPlugins).sortPlugins();
         logger.trace("ordered plugins: ({}) {}", orderedPlugins.size(), orderedPlugins);
@@ -224,9 +224,9 @@ public final class KernelCore implements Kernel
     }
 
     private void validateMandatoryParams() {
-        MandatoryParamsSpecification mandatoryParamsSpecification = new MandatoryParamsSpecification();
+        MandatoryParamsAsserter mandatoryParamsAsserter = new MandatoryParamsAsserter();
         for (Plugin plugin : pluginRegistry.getPlugins()) {
-            mandatoryParamsSpecification.isSatisfiedBy(plugin, kernelConfig.kernelParams());
+            mandatoryParamsAsserter.assertMandatoryParams(plugin, kernelConfig.kernelParams());
         }
     }
 
@@ -251,7 +251,7 @@ public final class KernelCore implements Kernel
 
     private List<Plugin> callPluginsInitMethod(final List<Plugin> plugins, int round)
     {
-        List<Plugin> nonInitializedPlugins = new ArrayList<Plugin>();
+        List<Plugin> nonInitializedPlugins = new ArrayList<>();
         for (Plugin plugin : plugins)
         {
             logger.info(" * {} plugin", plugin.name());

--- a/core/src/main/java/io/nuun/kernel/core/internal/MandatoryParamsAsserter.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/MandatoryParamsAsserter.java
@@ -24,9 +24,9 @@ import io.nuun.kernel.core.KernelException;
 import java.util.Collection;
 import java.util.HashSet;
 
-public class MandatoryParamsSpecification
+class MandatoryParamsAsserter
 {
-    public void isSatisfiedBy(Plugin plugin, AliasMap kernelParams) {
+    void assertMandatoryParams(Plugin plugin, AliasMap kernelParams) {
         Collection<KernelParamsRequest> requestedParams = plugin.kernelParamsRequests();
         Collection<String> mandatoryParams = filterMandatoryParams(requestedParams);
 
@@ -37,7 +37,7 @@ public class MandatoryParamsSpecification
 
     private Collection<String> filterMandatoryParams(Collection<KernelParamsRequest> kernelParamsRequests)
     {
-        Collection<String> computedMandatoryParams = new HashSet<String>();
+        Collection<String> computedMandatoryParams = new HashSet<>();
         for (KernelParamsRequest kernelParamsRequest : kernelParamsRequests) {
             if (kernelParamsRequest.requestType == KernelParamsRequestType.MANDATORY) {
                 computedMandatoryParams.add(kernelParamsRequest.keyRequested);

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginRegistry.java
@@ -35,8 +35,8 @@ class PluginRegistry
     private static final String TYPE_UNIQUENESS_ERROR = "The kernel contains two plugins of type ";
     private static final String NAME_VALIDATION_ERROR = "The plugin %s doesn't have a correct name. It should not be null or empty.";
 
-    private final Map<Class<? extends Plugin>, Plugin> pluginsByClass = new HashMap<Class<? extends Plugin>, Plugin>();
-    private final Map<String, Plugin> pluginsByName = new HashMap<String, Plugin>();
+    private final Map<Class<? extends Plugin>, Plugin> pluginsByClass = new HashMap<>();
+    private final Map<String, Plugin> pluginsByName = new HashMap<>();
 
     void add(Class<? extends Plugin> pluginClass)
     {

--- a/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/PluginSortStrategy.java
@@ -68,7 +68,7 @@ class PluginSortStrategy {
             throw new KernelException("Error when sorting plugins: either a Cycle in dependencies or another cause.");
         }
 
-        ArrayList<Plugin> sorted = new ArrayList<Plugin>();
+        ArrayList<Plugin> sorted = new ArrayList<>();
         for (Character label : topologicalSort) {
             sorted.add(vertices.getPlugin(label));
         }
@@ -92,7 +92,7 @@ class PluginSortStrategy {
     }
 
     private List<Class<?>> getCompleteDependencies(Class<?> declaredDependency) {
-        final List<Class<?>> dependencies = new ArrayList<Class<?>>();
+        final List<Class<?>> dependencies = new ArrayList<>();
         if (!Plugin.class.isAssignableFrom(declaredDependency)) {
             List<?> facets = facetRegistry.getFacets(declaredDependency);
             // TODO remove the need for this loop. Add a getFacetClasses in the FacetRegistry.
@@ -106,9 +106,9 @@ class PluginSortStrategy {
     }
 
     private static class Vertices {
-        Map<Integer, Plugin> pluginsByIndex = new HashMap<Integer, Plugin>();
-        Map<Character, Plugin> pluginsByLabel = new HashMap<Character, Plugin>();
-        Map<Class<?>, Integer> indexByPluginClasses = new HashMap<Class<?>, Integer>();
+        Map<Integer, Plugin> pluginsByIndex = new HashMap<>();
+        Map<Character, Plugin> pluginsByLabel = new HashMap<>();
+        Map<Class<?>, Integer> indexByPluginClasses = new HashMap<>();
 
         public void addVertex(char label, int index, Plugin plugin) {
             pluginsByLabel.put(label, plugin);

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/InstallerFactory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/InstallerFactory.java
@@ -33,7 +33,7 @@ public class InstallerFactory
     }
 
     List<Installer> createFromUnitModules(Collection<UnitModule> unitModules) {
-        List<Installer> installers = new ArrayList<Installer>();
+        List<Installer> installers = new ArrayList<>();
         for (UnitModule unitModule : unitModules)
         {
             installers.add(new UnitModuleInstaller(unitModule));
@@ -42,7 +42,7 @@ public class InstallerFactory
     }
 
     List<Installer> createFromClasses(Collection<Class<?>> classes) {
-        List<Installer> installerList = new ArrayList<Installer>();
+        List<Installer> installerList = new ArrayList<>();
         for (Class<?> aClass : classes)
         {
             installerList.add(new ClassInstaller(aClass, classesWithScopes.get(aClass)));

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/KernelGuiceModuleInternal.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/KernelGuiceModuleInternal.java
@@ -69,7 +69,7 @@ public class KernelGuiceModuleInternal extends AbstractModule
 
     private List<Installer> getComparableConcerns()
     {
-        List<Installer> installers = new ArrayList<Installer>();
+        List<Installer> installers = new ArrayList<>();
         InstallerFactory installerFactory = new InstallerFactory(requestHandler.getClassesWithScopes());
         if (!overriding)
         {

--- a/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleHandler.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/injection/ModuleHandler.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class ModuleHandler
 {
     private final KernelConfigurationInternal kernelConfig;
-    private final Collection<DependencyInjectionProvider> dependencyInjectionProviders = new ArrayList<DependencyInjectionProvider>();
+    private final Collection<DependencyInjectionProvider> dependencyInjectionProviders = new ArrayList<>();
 
     private final Map<Class<? extends Plugin>, UnitModule> unitModules = Maps.newConcurrentMap();
     private final Map<Class<? extends Plugin>, UnitModule> overridingUnitModules = Maps.newConcurrentMap();

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScanner.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/ClasspathScanner.java
@@ -16,18 +16,17 @@
  */
 package io.nuun.kernel.core.internal.scanner;
 
-import org.kametic.specifications.Specification;
-
 import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Predicate;
 
 public interface ClasspathScanner
 {
     Collection<Class<?>> scanTypes(String typeRegex);
 
-    Collection<Class<?>> scanTypes(Specification<Class<?>> specification);
+    Collection<Class<?>> scanTypes(Predicate<Class<?>> classPredicate);
 
     Collection<Class<?>> scanTypesAnnotatedBy(Class<? extends Annotation> annotationType);
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/disk/ClasspathScannerDisk.java
@@ -20,7 +20,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.nuun.kernel.core.internal.scanner.AbstractClasspathScanner;
 import io.nuun.kernel.core.internal.utils.AssertUtils;
-import org.kametic.specifications.Specification;
 import org.reflections.Reflections;
 import org.reflections.Store;
 import org.reflections.scanners.ResourcesScanner;
@@ -41,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import static io.nuun.kernel.core.internal.utils.NuunReflectionUtils.forNameSilent;
@@ -63,7 +63,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
     public ClasspathScannerDisk(ClasspathStrategy classpathStrategy, boolean reachAbstractClass, Set<URL> additionalClasspath, String... packageRoots)
     {
         super(reachAbstractClass);
-        this.packageRoots = new LinkedList<String>();
+        this.packageRoots = new LinkedList<>();
         Collections.addAll(this.packageRoots, packageRoots);
         this.classpathStrategy = classpathStrategy;
         this.additionalClasspath = additionalClasspath;
@@ -97,7 +97,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
     {
         if (urls == null)
         {
-            urls = new HashSet<URL>();
+            urls = new HashSet<>();
 
             switch (classpathStrategy.getStrategy())
             {
@@ -134,17 +134,17 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
     }
 
     @Override
-    public Collection<Class<?>> scanTypes(final Specification<Class<?>> specification)
+    public Collection<Class<?>> scanTypes(final Predicate<Class<?>> predicate)
     {
         Store store = reflections.getStore();
         Multimap<String, String> multimap = store.get(TypeElementsScanner.class.getSimpleName());
         Collection<String> types = multimap.keySet();
 
-        // Filter via specification
-        Collection<Class<?>> filteredTypes = new HashSet<Class<?>>();
+        // Filter via predicate
+        Collection<Class<?>> filteredTypes = new HashSet<>();
         for (Class<?> candidate : forNames(types))
         {
-            if (specification.isSatisfiedBy(candidate))
+            if (predicate.test(candidate))
             {
                 filteredTypes.add(candidate);
             }
@@ -163,7 +163,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
     {
         Store store = reflections.getStore();
         Multimap<String, String> multimap = store.get(TypeElementsScanner.class.getSimpleName());
-        Collection<String> collectionOfString = new HashSet<String>();
+        Collection<String> collectionOfString = new HashSet<>();
         for (String loopKey : multimap.keySet())
         {
             if (loopKey.matches(typeRegex))
@@ -182,7 +182,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
 
         Multimap<String, String> multimap = store.get(TypeAnnotationsScanner.class.getSimpleName());
 
-        List<String> key = new ArrayList<String>();
+        List<String> key = new ArrayList<>();
         for (String loopKey : multimap.keySet())
         {
             if (loopKey.matches(annotationTypeRegex))
@@ -191,7 +191,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
             }
         }
 
-        Collection<Class<?>> typesAnnotatedWith = new HashSet<Class<?>>();
+        Collection<Class<?>> typesAnnotatedWith = new HashSet<>();
 
         for (String k : key)
         {
@@ -247,7 +247,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
         Store store = reflections.getStore();
         Multimap<String, String> multimap = store.get(TypeElementsScanner.class.getSimpleName());
 
-        Collection<String> types = new HashSet<String>();
+        Collection<String> types = new HashSet<>();
 
         for (String loopKey : multimap.keySet())
         {
@@ -258,7 +258,7 @@ public class ClasspathScannerDisk extends AbstractClasspathScanner
         }
 
         // Then find subclasses of types
-        Collection<Class<?>> finalClasses = new HashSet<Class<?>>();
+        Collection<Class<?>> finalClasses = new HashSet<>();
         for (Class<?> subType : forNames(types))
         {
             finalClasses.addAll(postTreatment((Collection) reflections.getSubTypesOf(subType)));

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathBuilder.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathBuilder.java
@@ -37,7 +37,7 @@ public abstract class ClasspathBuilder
 
     public ClasspathBuilder()
     {
-        entries = new HashMap<String, ClasspathAbstractContainer<?>>();
+        entries = new HashMap<>();
     }
 
     protected void addJar(String name)

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/ClasspathScannerInMemory.java
@@ -34,7 +34,7 @@ import java.util.Set;
 public class ClasspathScannerInMemory extends ClasspathScannerDisk
 {
     private final Classpath classpath;
-    private final Set<URL> urls = new HashSet<URL>();
+    private final Set<URL> urls = new HashSet<>();
 
     public ClasspathScannerInMemory(Classpath classpath, String... packageRoot)
     {

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryMultiThreadClasspath.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryMultiThreadClasspath.java
@@ -38,7 +38,7 @@ public enum InMemoryMultiThreadClasspath implements Classpath {
 	{
 		@Override
 		protected java.util.Map<String , ClasspathAbstractContainer<?>> initialValue() {
-			return new HashMap<String , ClasspathAbstractContainer<?>>();
+			return new HashMap<>();
 		}
 	};
 

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlType.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/InMemoryUrlType.java
@@ -80,7 +80,7 @@ public class InMemoryUrlType implements UrlType
 
 			// TODO ne renvoyer que l'entry de l'url donné en paramêtre
 			
-			List<File> files = new ArrayList<Vfs.File>();
+			List<File> files = new ArrayList<>();
 		    
 			for ( ClasspathAbstractElement<?> entry : classpath.entry(path).entries() )
 			{

--- a/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/MetadataAdapterInMemory.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/scanner/inmemory/MetadataAdapterInMemory.java
@@ -50,7 +50,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<String> getInterfacesNames(Class<?> cls) {
-		List<String> itfNames = new ArrayList<String>();
+		List<String> itfNames = new ArrayList<>();
 		
 		for (Class<?> c : cls.getInterfaces()) {
 			itfNames.add(c.getName());
@@ -60,7 +60,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<Field> getFields(Class<?> cls) {
-		List<Field> fl = new ArrayList<Field>();
+		List<Field> fl = new ArrayList<>();
 		
 		for (Field f : cls.getDeclaredFields()) {
 			fl.add(f);
@@ -71,7 +71,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<Method> getMethods(Class<?> cls) {
-		List<Method> fm = new ArrayList<Method>();
+		List<Method> fm = new ArrayList<>();
 		
 		for (Method f : cls.getDeclaredMethods()) {
 			fm.add(f);
@@ -88,7 +88,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<String> getParameterNames(Method method) {
-		List<String> parNames = new ArrayList<String>();
+		List<String> parNames = new ArrayList<>();
 		int i = 0;
 		for (@SuppressWarnings("unused") Class<?> c : method.getParameterTypes()) {
 			parNames.add("" + i);
@@ -100,7 +100,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<String> getClassAnnotationNames(Class<?> aClass) {
-		List<String> fm = new ArrayList<String>();
+		List<String> fm = new ArrayList<>();
 		
 		for (Annotation anno : aClass.getAnnotations()) {
 			fm.add(anno.annotationType().getName());
@@ -112,7 +112,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 	@Override
 	public List<String> getFieldAnnotationNames(Field field) {
 		
-		List<String> fm = new ArrayList<String>();
+		List<String> fm = new ArrayList<>();
 		
 		for (Annotation anno : field.getAnnotations()) {
 			fm.add(anno.annotationType().getName());
@@ -123,7 +123,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 
 	@Override
 	public List<String> getMethodAnnotationNames(Method method) {
-		List<String> fm = new ArrayList<String>();
+		List<String> fm = new ArrayList<>();
 		
 		for (Annotation anno : method.getAnnotations()) {
 			fm.add(anno.annotationType().getName());
@@ -135,7 +135,7 @@ public class MetadataAdapterInMemory implements MetadataAdapter<Class<?>, Field,
 	@Override
 	public List<String> getParameterAnnotationNames(Method method, int parameterIndex) {
 		
-		List<String> fm = new ArrayList<String>();
+		List<String> fm = new ArrayList<>();
 		
 		if (parameterIndex  < method.getParameterAnnotations().length ) {
 			for (Annotation anno : method.getAnnotations()) {

--- a/core/src/main/java/io/nuun/kernel/core/internal/utils/NuunReflectionUtils.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/utils/NuunReflectionUtils.java
@@ -37,9 +37,7 @@ public class NuunReflectionUtils {
     public static <T> T instantiateOrFail(Class<?> aClass) {
         try {
             return (T) aClass.newInstance();
-        } catch (InstantiationException e) {
-            throw new PluginException(e);
-        } catch (IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException e) {
             throw new PluginException(e);
         }
     }

--- a/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/DependencyProviderTest.java
@@ -84,13 +84,13 @@ public class DependencyProviderTest
         @Override
         public Collection<Class<?>> requiredPlugins()
         {
-            return Lists.<Class<?>>newArrayList(Facet1.class, Facet2.class);
+            return Lists.newArrayList(Facet1.class, Facet2.class);
         }
 
         @Override
         public Collection<Class<?>> dependentPlugins()
         {
-            return Lists.<Class<?>>newArrayList(DependentPlugin.class);
+            return Lists.newArrayList(DependentPlugin.class);
         }
     }
 
@@ -114,13 +114,13 @@ public class DependencyProviderTest
     {
         FacetRegistry facetRegistry = Mockito.mock(FacetRegistry.class);
 
-        List<Facet1> requiredPlugins = new ArrayList<Facet1>();
+        List<Facet1> requiredPlugins = new ArrayList<>();
         requiredPlugin1 = new RequiredPlugin1();
         requiredPlugin2 = new RequiredPlugin2();
         requiredPlugins.add(requiredPlugin1);
         requiredPlugins.add(requiredPlugin2);
 
-        List<DependentPlugin> dependentPlugins = new ArrayList<DependentPlugin>();
+        List<DependentPlugin> dependentPlugins = new ArrayList<>();
         dependentPlugin = new DependentPlugin();
         dependentPlugins.add(dependentPlugin);
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
@@ -38,7 +38,7 @@ public class ExtensionManagerIT
     @Before
     public void setup()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         plugins.add(new DummyExtensionPlugin());
         underTest = new ExtensionManager(plugins, Thread.currentThread().getContextClassLoader());
     }

--- a/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/FacetRegistryTest.java
@@ -30,14 +30,14 @@ public class FacetRegistryTest
     @Test
     public void get_null_is_accepted()
     {
-        FacetRegistry registry = new FacetRegistry(new ArrayList<Plugin>());
-        Assertions.assertThat(registry.getFacet(null)).isNull();
+        FacetRegistry registry = new FacetRegistry(new ArrayList<>());
+        Assertions.assertThat((Object)registry.getFacet(null)).isNull();
     }
 
     @Test
     public void scan_a_plugin_facet()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
         plugins.add(oneFacetPlugin);
 
@@ -50,7 +50,7 @@ public class FacetRegistryTest
     @Test
     public void scan_multiple_facet_in_a_plugin()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
         plugins.add(twoFacetPlugin);
 
@@ -67,7 +67,7 @@ public class FacetRegistryTest
     @Test(expected = IllegalStateException.class)
     public void getFacet_fails_for_multiple_facet_implementation()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
         TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
         plugins.add(oneFacetPlugin);
@@ -80,7 +80,7 @@ public class FacetRegistryTest
     @Test
     public void getFacets_never_return_null()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
         plugins.add(oneFacetPlugin);
 
@@ -94,7 +94,7 @@ public class FacetRegistryTest
     @Test
     public void get_multiple_facet_implementations()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         OneFacetPlugin oneFacetPlugin = new OneFacetPlugin();
         TwoFacetPlugin twoFacetPlugin = new TwoFacetPlugin();
         plugins.add(oneFacetPlugin);
@@ -119,7 +119,7 @@ public class FacetRegistryTest
     @Test
     public void get_plugin_implementation()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
         LegacyPlugin legacyPlugin = new LegacyPlugin();
         plugins.add(legacyPlugin);
 
@@ -135,7 +135,7 @@ public class FacetRegistryTest
     @Test
     public void get_missing_plugin_implementations()
     {
-        List<Plugin> plugins = new ArrayList<Plugin>();
+        List<Plugin> plugins = new ArrayList<>();
 
         FacetRegistry registry = new FacetRegistry(plugins);
         List<LegacyPlugin> legacyPlugins = registry.getFacets(LegacyPlugin.class);

--- a/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/InternalKernelModuleTest.java
@@ -38,7 +38,7 @@ public class InternalKernelModuleTest
     @Before
     public void init()
     {
-        RequestHandler requestHandler = new RequestHandler(new HashMap<String, String>(), new KernelOptions());
+        RequestHandler requestHandler = new RequestHandler(new HashMap<>(), new KernelOptions());
         underTest = new KernelGuiceModuleInternal(requestHandler);
     }
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/KernelCoreIT.java
@@ -183,7 +183,7 @@ public class KernelCoreIT
     }
 
     @Test
-    public void classpath_scan_by_specification_should_work()
+    public void classpath_scan_by_predicate_should_work()
     {
         assertThat(plugin4.collection).isNotNull();
         assertThat(plugin4.collection).isNotEmpty();
@@ -192,7 +192,7 @@ public class KernelCoreIT
     }
 
     @Test
-    public void binding_by_specification_should_work()
+    public void binding_by_predicate_should_work()
     {
         assertThat(injector.getInstance(Pojo2.class)).isNotNull();
         // we check for the scope
@@ -293,7 +293,7 @@ public class KernelCoreIT
     @Test
     public void plugin_sort_algorithm() throws Exception
     {
-        ArrayList<Plugin> plugins = new ArrayList<Plugin>(), plugins2;
+        ArrayList<Plugin> plugins = new ArrayList<>(), plugins2;
 
         p1 e1 = new p1();
         plugins.add(e1);
@@ -335,7 +335,7 @@ public class KernelCoreIT
     {
         public Collection<Class<?>> dep(Class<?> klazz)
         {
-            return Lists.<Class<?>>newArrayList(klazz);
+            return Lists.newArrayList(klazz);
         }
     }
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/PluginSortStrategyTest.java
@@ -44,7 +44,7 @@ public class PluginSortStrategyTest
         Plugin3 plugin3 = new Plugin3(); // declare P2 as required and declare P4 as dependent
         Plugin4 plugin4 = new Plugin4();
 
-        List<Plugin> plugins = Lists.<Plugin>newArrayList(plugin4, plugin2, plugin3, plugin1);
+        List<Plugin> plugins = Lists.newArrayList(plugin4, plugin2, plugin3, plugin1);
         FacetRegistry facetRegistry = new FacetRegistry(plugins);
         PluginSortStrategy strategy = new PluginSortStrategy(facetRegistry, plugins);
         List<Plugin> orderedPlugins = strategy.sortPlugins();
@@ -71,7 +71,7 @@ public class PluginSortStrategyTest
         @Override
         public Collection<Class<?>> dependentPlugins()
         {
-            return Lists.<Class<?>>newArrayList(Facet1.class);
+            return Lists.newArrayList(Facet1.class);
         }
     }
 
@@ -95,13 +95,13 @@ public class PluginSortStrategyTest
         @Override
         public Collection<Class<?>> dependentPlugins()
         {
-            return Lists.<Class<?>>newArrayList(Plugin4.class);
+            return Lists.newArrayList(Plugin4.class);
         }
 
         @Override
         public Collection<Class<?>> requiredPlugins()
         {
-            return Lists.<Class<?>>newArrayList(Facet1.class);
+            return Lists.newArrayList(Facet1.class);
         }
     }
 

--- a/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/concerns/ConcernTest.java
@@ -41,7 +41,7 @@ public class ConcernTest
     @BeforeClass
     public static void init()
     {
-        list = new ArrayList<String>();
+        list = new ArrayList<>();
         underTest = Fixture.startKernel(Fixture.config()
                 .plugins(
                         new InternalPlugin(),

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy1/DummyPlugin.java
@@ -105,7 +105,7 @@ public class DummyPlugin extends AbstractPlugin
         Map<String, Collection<Class<?>>> scannedTypesByRegex = initContext.scannedTypesByRegex();
         Collection<Class<?>> cParent3 = scannedTypesByRegex.get(".*WithCustomSuffix");
 
-        Collection<Class<?>> classes = new HashSet<Class<?>>();
+        Collection<Class<?>> classes = new HashSet<>();
         classes.addAll(cParent3);
         classes.addAll(cParent2);
         classes.addAll(cParent1);
@@ -147,7 +147,7 @@ public class DummyPlugin extends AbstractPlugin
     @Override
     public Collection<Class<?>> requiredPlugins()
     {
-        return Lists.<Class<?>>newArrayList(DummyPlugin2.class);
+        return Lists.newArrayList(DummyPlugin2.class);
     }
 
     @Override
@@ -160,7 +160,7 @@ public class DummyPlugin extends AbstractPlugin
     @Override
     public Map<String, String> kernelParametersAliases()
     {
-        Map<String, String> m = new HashMap<String, String>();
+        Map<String, String> m = new HashMap<>();
         m.put(NUUN_ROOT_ALIAS, "nuun.root.package");
         m.put(ALIAS_DUMMY_PLUGIN1, "dummy.plugin1");
         return m;

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy23/DummyPlugin2.java
@@ -40,7 +40,7 @@ public class DummyPlugin2 extends AbstractPlugin
     @Override
     public Collection<Class<?>> requiredPlugins()
     {
-        return Lists.<Class<?>>newArrayList(DummyPlugin3.class);
+        return Lists.newArrayList(DummyPlugin3.class);
     }
 
     @Override

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/DummyPlugin4.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy4/DummyPlugin4.java
@@ -21,18 +21,20 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.BindingRequest;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.predicates.ClassAnnotatedWith;
+import io.nuun.kernel.api.predicates.ClassImplements;
 import io.nuun.kernel.core.AbstractPlugin;
-import org.kametic.specifications.Specification;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DummyPlugin4 extends AbstractPlugin
 {
     public Collection<Class<?>> collection;
-    private Specification<Class<?>> specification;
+    private Predicate<Class<?>> predicate;
 
     public DummyPlugin4()
     {
@@ -48,24 +50,24 @@ public class DummyPlugin4 extends AbstractPlugin
     @SuppressWarnings("unchecked")
     public Collection<BindingRequest> bindingRequests()
     {
-        Specification<Class<?>> specification = and(classAnnotatedWith(MarkerSample5.class), classImplements(Interface2.class));
+        Predicate<Class<?>> predicate = new ClassAnnotatedWith(MarkerSample5.class).and(new ClassImplements(Interface2.class));
 
-        assertThat(specification.isSatisfiedBy(Pojo1.class)).isFalse();
-        assertThat(specification.isSatisfiedBy(Pojo2.class)).isTrue();
+        assertThat(predicate.test(Pojo1.class)).isFalse();
+        assertThat(predicate.test(Pojo2.class)).isTrue();
 
-        return bindingRequestsBuilder().specification(specification).withScope(Scopes.SINGLETON).build();
+        return bindingRequestsBuilder().predicate(predicate).withScope(Scopes.SINGLETON).build();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public Collection<ClasspathScanRequest> classpathScanRequests()
     {
-        specification = and(classAnnotatedWith(MarkerSample5.class), classImplements(Interface1.class));
+        predicate = new ClassAnnotatedWith(MarkerSample5.class).and(new ClassImplements(Interface1.class));
 
-        assertThat(specification.isSatisfiedBy(Pojo1.class)).isTrue();
-        assertThat(specification.isSatisfiedBy(Pojo2.class)).isFalse();
+        assertThat(predicate.test(Pojo1.class)).isTrue();
+        assertThat(predicate.test(Pojo2.class)).isFalse();
 
-        return classpathScanRequestBuilder().specification(specification).build();
+        return classpathScanRequestBuilder().predicate(predicate).build();
     }
 
 
@@ -73,9 +75,9 @@ public class DummyPlugin4 extends AbstractPlugin
     @Override
     public InitState init(InitContext initContext)
     {
-        Map<Specification, Collection<Class<?>>> scannedTypesBySpecification = initContext.scannedTypesBySpecification();
+        Map<Predicate<Class<?>>, Collection<Class<?>>> scannedTypesByPredicate = initContext.scannedTypesByPredicate();
 
-        collection = scannedTypesBySpecification.get(specification);
+        collection = scannedTypesByPredicate.get(predicate);
 
         assertThat(collection).isNotEmpty();
         assertThat(collection).hasSize(1);

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DummyPlugin5.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy5/DummyPlugin5.java
@@ -21,10 +21,12 @@ import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.BindingRequest;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.predicates.ClassDescendantOf;
 import io.nuun.kernel.core.AbstractPlugin;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +34,7 @@ public class DummyPlugin5 extends AbstractPlugin
 {
 
     public Collection<Class<?>> collection;
+    private final ClassDescendantOf descendantOfGrandParentClass = new ClassDescendantOf(GrandParentClass.class);
 
 
     public DummyPlugin5()
@@ -47,9 +50,8 @@ public class DummyPlugin5 extends AbstractPlugin
     @Override
     public Collection<BindingRequest> bindingRequests()
     {
-
         return bindingRequestsBuilder() //
-                .descendentTypeOf(GrandParentClass.class).withScope(Scopes.SINGLETON) //
+                .predicate(descendantOfGrandParentClass).withScope(Scopes.SINGLETON) //
                 .metaAnnotationType(MetaMarkerSample.class).withScope(Scopes.SINGLETON) //
                 .metaAnnotationRegex(".*YMetaMarker.*").withScope(Scopes.SINGLETON)
 //                .descendentTypeOf(GrandParentInterface.class) //
@@ -61,8 +63,8 @@ public class DummyPlugin5 extends AbstractPlugin
     {
 
         return classpathScanRequestBuilder()
-                .descendentTypeOf(GrandParentClass.class) //
-                .descendentTypeOf(GrandParentInterface.class) //
+                .predicate(descendantOfGrandParentClass) //
+                .predicate(new ClassDescendantOf(GrandParentInterface.class)) //
                 .build();
     }
 
@@ -70,9 +72,9 @@ public class DummyPlugin5 extends AbstractPlugin
     @Override
     public InitState init(InitContext initContext)
     {
-        Map<Class<?>, Collection<Class<?>>> scannedSubTypesByAncestorClass = initContext.scannedSubTypesByAncestorClass();
+        Map<Predicate<Class<?>>, Collection<Class<?>>> scannedSubTypesByPredicate = initContext.scannedTypesByPredicate();
 
-        collection = scannedSubTypesByAncestorClass.get(GrandParentClass.class);
+        collection = scannedSubTypesByPredicate.get(descendantOfGrandParentClass);
 
         assertThat(collection).isNotEmpty();
         assertThat(collection).hasSize(2);

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/dummy6/DummyPlugin6_B.java
@@ -51,7 +51,7 @@ public class DummyPlugin6_B extends AbstractPlugin
     {
         if (round.isFirst())
         {
-            return Lists.<Class<?>>newArrayList(DummyPlugin6_D.class, DummyPlugin6_C.class);
+            return Lists.newArrayList(DummyPlugin6_D.class, DummyPlugin6_C.class);
         } else
         {
             return super.dependentPlugins();

--- a/core/src/test/java/it/AliasIT.java
+++ b/core/src/test/java/it/AliasIT.java
@@ -73,7 +73,7 @@ public class AliasIT
         @Override
         public Map<String, String> kernelParametersAliases()
         {
-            Map<String, String> aliases = new HashMap<String, String>();
+            Map<String, String> aliases = new HashMap<>();
             aliases.put("alias1", "param1");
             aliases.put("alias2", "param2");
             return aliases;

--- a/core/src/test/java/it/ClasspathScanningIT.java
+++ b/core/src/test/java/it/ClasspathScanningIT.java
@@ -38,7 +38,7 @@ public class ClasspathScanningIT
 {
 
     /**
-     * Tests if the plugin ScanningPlugin is able to scan classes using specification.
+     * Tests if the plugin ScanningPlugin is able to scan classes using predicates.
      * All the classes annotated or meta annotation with {@code Ignore} should be ignored.
      */
     @Test

--- a/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithDependentDepsPlugin.java
@@ -61,6 +61,6 @@ public class WithDependentDepsPlugin extends AbstractPlugin
     @Override
     public Collection<Class<?>> dependentPlugins()
     {
-        return Lists.<Class<?>>newArrayList(DependentPlugin1.class);
+        return Lists.newArrayList(DependentPlugin1.class);
     }
 }

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredDepsPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredDepsPlugin.java
@@ -61,7 +61,7 @@ public class WithRequiredDepsPlugin extends AbstractPlugin
     @Override
     public Collection<Class<?>> requiredPlugins()
     {
-        return Lists.<Class<?>>newArrayList(RequiredPlugin1.class);
+        return Lists.newArrayList(RequiredPlugin1.class);
     }
 
 }

--- a/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
+++ b/core/src/test/java/it/fixture/dependencies/WithRequiredFacetPlugin.java
@@ -68,6 +68,6 @@ public class WithRequiredFacetPlugin extends AbstractPlugin
     @Override
     public Collection<Class<?>> requiredPlugins()
     {
-        return Lists.<Class<?>>newArrayList(Facet1.class);
+        return Lists.newArrayList(Facet1.class);
     }
 }

--- a/core/src/test/java/it/fixture/scan/ScanningPlugin.java
+++ b/core/src/test/java/it/fixture/scan/ScanningPlugin.java
@@ -19,10 +19,11 @@ package it.fixture.scan;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.predicates.ClassAnnotatedWith;
 import io.nuun.kernel.core.AbstractPlugin;
-import org.kametic.specifications.Specification;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 
 /**
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
@@ -32,7 +33,7 @@ public class ScanningPlugin extends AbstractPlugin
 
     public static final String NAME = "scanning";
 
-    public final Specification<Class<?>> TO_SCAN_SPEC = classAnnotatedWith(ToScan.class);
+    public final Predicate<Class<?>> TO_SCAN_PREDICATE = new ClassAnnotatedWith(ToScan.class);
 
     private Collection<Class<?>> scannedClasses;
 
@@ -45,13 +46,13 @@ public class ScanningPlugin extends AbstractPlugin
     @Override
     public Collection<ClasspathScanRequest> classpathScanRequests()
     {
-        return classpathScanRequestBuilder().specification(TO_SCAN_SPEC).build();
+        return classpathScanRequestBuilder().predicate(TO_SCAN_PREDICATE).build();
     }
 
     @Override
     public InitState init(InitContext initContext)
     {
-        scannedClasses = initContext.scannedTypesBySpecification().get(TO_SCAN_SPEC);
+        scannedClasses = initContext.scannedTypesByPredicate().get(TO_SCAN_PREDICATE);
         return InitState.INITIALIZED;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <license-check.skip>false</license-check.skip>
         <license-check.fail>true</license-check.fail>
@@ -76,12 +76,6 @@
     </properties>
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.16</version>
-        </dependency>
 
         <!-- ========================================================== -->
         <!-- ============== UNIT TEST DEPENDENCIES ==================== -->

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -16,58 +16,37 @@
     along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses />.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>io.nuun</groupId>
-		<artifactId>kernel</artifactId>
-		<version>1.0.M10-SNAPSHOT</version>
-	</parent>
+    <parent>
+        <groupId>io.nuun</groupId>
+        <artifactId>kernel</artifactId>
+        <version>1.0.M10-SNAPSHOT</version>
+    </parent>
 
-	<artifactId>kernel-specs</artifactId>
-	<packaging>jar</packaging>
+    <artifactId>kernel-specs</artifactId>
+    <packaging>jar</packaging>
 
-	<name>Nuun IO Kernel Specs</name>
+    <name>Nuun IO Kernel Specs</name>
 
-	<description>
-    This is the specs part of the Nuun IO Kernel. API and SPI.
-    Use this project for your specs oriented projects.
+    <description>
+        This is the specs part of the Nuun IO Kernel. API and SPI.
+        Use this project for your specs oriented projects.
 
-    See kernel parent description.
-        
-  </description>
+        See kernel parent description.
 
-	<inceptionYear>2012</inceptionYear>
+    </description>
 
-	<licenses>
-		<license>
-			<name>LGPL 3.0</name>
-			<url>http://www.gnu.org/copyleft/lesser.html</url>
-		</license>
-	</licenses>
+    <inceptionYear>2012</inceptionYear>
 
-	<url>http://nuun.io/kernel/specs</url>
+    <licenses>
+        <license>
+            <name>LGPL 3.0</name>
+            <url>http://www.gnu.org/copyleft/lesser.html</url>
+        </license>
+    </licenses>
 
-	<dependencies>
-
-		<dependency>
-			<groupId>org.kametic</groupId>
-			<artifactId>specifications</artifactId>
-			<version>1.0.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
-			<version>2.0.1</version>
-		</dependency>
-	</dependencies>
-
+    <url>http://nuun.io/kernel/specs</url>
 </project>

--- a/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
+++ b/specs/src/main/java/io/nuun/kernel/api/config/KernelOptions.java
@@ -23,18 +23,18 @@ import java.util.Map;
 
 public class KernelOptions
 {
-    public static final KernelOption<List<String>> ROOT_PACKAGES = new KernelOption<List<String>>("root.packages");
-    public static final KernelOption<Boolean> PRINT_SCAN_WARN = new KernelOption<Boolean>("scan.warn.disable");
-    public static final KernelOption<Boolean> ENABLE_REFLECTION_LOGGER = new KernelOption<Boolean>("reflection.logger.disable");
-    public static final KernelOption<Boolean> SCAN_PLUGIN = new KernelOption<Boolean>("plugin.scan.disable");
-    public static final KernelOption<ClasspathScanMode> CLASSPATH_SCAN_MODE = new KernelOption<ClasspathScanMode>("classpath.scan.mode");
-    public static final KernelOption<DependencyInjectionMode> DEPENDENCY_INJECTION_MODE = new KernelOption<DependencyInjectionMode>("dependency.injection.mode");
+    public static final KernelOption<List<String>> ROOT_PACKAGES = new KernelOption<>("root.packages");
+    public static final KernelOption<Boolean> PRINT_SCAN_WARN = new KernelOption<>("scan.warn.disable");
+    public static final KernelOption<Boolean> ENABLE_REFLECTION_LOGGER = new KernelOption<>("reflection.logger.disable");
+    public static final KernelOption<Boolean> SCAN_PLUGIN = new KernelOption<>("plugin.scan.disable");
+    public static final KernelOption<ClasspathScanMode> CLASSPATH_SCAN_MODE = new KernelOption<>("classpath.scan.mode");
+    public static final KernelOption<DependencyInjectionMode> DEPENDENCY_INJECTION_MODE = new KernelOption<>("dependency.injection.mode");
 
-    private final Map<String, Object> options = new HashMap<String, Object>();
+    private final Map<String, Object> options = new HashMap<>();
 
     public KernelOptions()
     {
-        set(ROOT_PACKAGES, new ArrayList<String>());
+        set(ROOT_PACKAGES, new ArrayList<>());
         set(PRINT_SCAN_WARN, true);
         set(ENABLE_REFLECTION_LOGGER, false);
         set(SCAN_PLUGIN, true);

--- a/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractContainer.java
+++ b/specs/src/main/java/io/nuun/kernel/api/inmemory/ClasspathAbstractContainer.java
@@ -31,7 +31,7 @@ public abstract class ClasspathAbstractContainer< S extends ClasspathAbstractCon
 
 	protected S myself;
 	protected String name;
-	protected List<ClasspathAbstractElement<?>> entries = new ArrayList<ClasspathAbstractElement<?>>();
+	protected List<ClasspathAbstractElement<?>> entries = new ArrayList<>();
 
 	
 	public ClasspathAbstractContainer(String name)

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/context/InitContext.java
@@ -17,12 +17,12 @@
 package io.nuun.kernel.api.plugin.context;
 
 import io.nuun.kernel.api.di.UnitModule;
-import org.kametic.specifications.Specification;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  * The holder class containing all the data available at the {@code init} step.
@@ -32,8 +32,6 @@ import java.util.Map;
 public interface InitContext
 {
     Map<Class<?>, Collection<Class<?>>> scannedSubTypesByParentClass();
-
-    Map<Class<?>, Collection<Class<?>>> scannedSubTypesByAncestorClass();
 
     Map<String, Collection<Class<?>>> scannedSubTypesByParentRegex();
 
@@ -59,7 +57,7 @@ public interface InitContext
 
     Map<String, Collection<String>> mapResourcesByRegex();
 
-    Map<Specification, Collection<Class<?>>> scannedTypesBySpecification();
+    Map<Predicate<Class<?>>, Collection<Class<?>>> scannedTypesByPredicate();
 
     /**
      * Returns plugin instances required by the current plugin.

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequest.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequest.java
@@ -16,8 +16,7 @@
  */
 package io.nuun.kernel.api.plugin.request;
 
-import org.kametic.specifications.Specification;
-
+import java.util.function.Predicate;
 
 /**
  * @author Epo Jemba
@@ -27,7 +26,7 @@ public class BindingRequest {
 
     public final RequestType requestType;
     public final Object requestedObject;
-    public final Specification<Class<?>> specification;
+    public final Predicate<Class<?>> predicate;
     public Object requestedScope;
     public Object requestedConstraint;
 
@@ -35,15 +34,15 @@ public class BindingRequest {
         this(requestType, keyRequested, null, null);
     }
 
-    public BindingRequest(RequestType requestType, Object requestedScope, Specification<Class<?>> specification) {
-        this(requestType, null, requestedScope, specification);
+    public BindingRequest(RequestType requestType, Object requestedScope, Predicate<Class<?>> predicate) {
+        this(requestType, null, requestedScope, predicate);
     }
 
-    public BindingRequest(RequestType requestType, Object keyRequested, Object requestedScope, Specification<Class<?>> specification) {
+    public BindingRequest(RequestType requestType, Object keyRequested, Object requestedScope, Predicate<Class<?>> classPredicate) {
         this.requestType = requestType;
         this.requestedObject = keyRequested;
         this.requestedScope = requestedScope;
-        this.specification = specification;
+        this.predicate = classPredicate;
     }
 
 }

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/BindingRequestBuilder.java
@@ -25,8 +25,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-
-import org.kametic.specifications.Specification;
+import java.util.function.Predicate;
 
 /**
  * @author Epo Jemba
@@ -38,13 +37,13 @@ public class BindingRequestBuilder implements BindingRequestBuilderOptionsBuildM
     
     public BindingRequestBuilder()
     {
-        requests = new HashSet<BindingRequest>();
+        requests = new HashSet<>();
     }
 
     @Override
-    public BindingRequestBuilderOptionsBuildMain specification(Specification<Class<?>> specification)
+    public BindingRequestBuilderOptionsBuildMain predicate(Predicate<Class<?>> classPredicate)
     {
-        requests.add(currentBindingRequest = new BindingRequest(RequestType.VIA_SPECIFICATION, null,specification));
+        requests.add(currentBindingRequest = new BindingRequest(RequestType.CLASS_PREDICATE, null, classPredicate));
         return this;
     }
 
@@ -80,13 +79,6 @@ public class BindingRequestBuilder implements BindingRequestBuilderOptionsBuildM
     {
         requests.add(currentBindingRequest = new BindingRequest(RequestType.SUBTYPE_OF_BY_CLASS, parentTypeRequested));
         
-        return this;
-    }
-
-    @Override
-    public BindingRequestBuilderOptionsBuildMain descendentTypeOf(Class<?> ancestorTypeRequested)
-    {
-        requests.add(currentBindingRequest = new BindingRequest(RequestType.SUBTYPE_OF_BY_TYPE_DEEP, ancestorTypeRequested));
         return this;
     }
 

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequest.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequest.java
@@ -19,8 +19,7 @@
  */
 package io.nuun.kernel.api.plugin.request;
 
-import org.kametic.specifications.Specification;
-
+import java.util.function.Predicate;
 
 /**
  * @author Epo Jemba
@@ -31,18 +30,18 @@ public class ClasspathScanRequest
 
     public final RequestType requestType;
     public final Object objectRequested;
-    public final Specification<Class<?>> specification;
+    public final Predicate<Class<?>> classPredicate;
 
     public ClasspathScanRequest(RequestType requestType , Object keyRequested)
     {
         this.requestType = requestType;
         this.objectRequested = keyRequested;
-        this.specification = null;
+        this.classPredicate = null;
     }
-    public ClasspathScanRequest(Specification<Class<?>> specification)
+    public ClasspathScanRequest(Predicate<Class<?>> classPredicate)
     {
-        this.specification = specification;
-        this.requestType = RequestType.VIA_SPECIFICATION;
+        this.classPredicate = classPredicate;
+        this.requestType = RequestType.CLASS_PREDICATE;
         this.objectRequested = null;
     }
     

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/ClasspathScanRequestBuilder.java
@@ -23,8 +23,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-
-import org.kametic.specifications.Specification;
+import java.util.function.Predicate;
 
 
 /**
@@ -41,14 +40,14 @@ public class ClasspathScanRequestBuilder implements Builder<Collection<Classpath
      */
     public ClasspathScanRequestBuilder()
     {
-        requests = new HashSet<ClasspathScanRequest>();
+        requests = new HashSet<>();
     }
     
     
-    public ClasspathScanRequestBuilder specification(Specification<Class<?>> specification)
+    public ClasspathScanRequestBuilder predicate(Predicate<Class<?>> classPredicate)
     {
         
-        requests.add(new ClasspathScanRequest(specification));
+        requests.add(new ClasspathScanRequest(classPredicate));
         
         return this;
     }
@@ -78,13 +77,6 @@ public class ClasspathScanRequestBuilder implements Builder<Collection<Classpath
     }
     
 
-    public ClasspathScanRequestBuilder descendentTypeOf(Class<?> parentTypeRequested)
-    {
-
-        requests.add(new ClasspathScanRequest(RequestType.SUBTYPE_OF_BY_TYPE_DEEP, parentTypeRequested));
-        return this;
-    }
-    
     public ClasspathScanRequestBuilder subtypeOfRegex(String parentTypeRegex)
     {
         

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestBuilder.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/KernelParamsRequestBuilder.java
@@ -38,7 +38,7 @@ public class KernelParamsRequestBuilder implements Builder<Collection<KernelPara
      */
     public KernelParamsRequestBuilder()
     {
-        requests = new HashSet<KernelParamsRequest>();
+        requests = new HashSet<>();
     }
     
     

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/RequestType.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/RequestType.java
@@ -37,10 +37,6 @@ public enum RequestType
      * Request classes based on type of direct parent class
      */
     SUBTYPE_OF_BY_REGEX_MATCH,
-    /**
-     * Request classes based on type of ancestor class
-     */
-    SUBTYPE_OF_BY_TYPE_DEEP,
-    VIA_SPECIFICATION,
+    CLASS_PREDICATE,
     RESOURCES_REGEX_MATCH
 }

--- a/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderMain.java
+++ b/specs/src/main/java/io/nuun/kernel/api/plugin/request/builders/BindingRequestBuilderMain.java
@@ -17,19 +17,17 @@
 package io.nuun.kernel.api.plugin.request.builders;
 
 import java.lang.annotation.Annotation;
-
-import org.kametic.specifications.Specification;
+import java.util.function.Predicate;
 
 public  interface BindingRequestBuilderMain 
 {
-    public BindingRequestBuilderOptionsBuildMain specification(Specification<Class<?>> specification);
-    public BindingRequestBuilderOptionsBuildMain annotationType(Class<? extends Annotation> annotationTypeRequested);
-    public BindingRequestBuilderOptionsBuildMain annotationRegex(String annotationRegex);
-    public BindingRequestBuilderOptionsBuildMain subtypeOf(Class<?> parentTypeRequested);
-    public BindingRequestBuilderOptionsBuildMain descendentTypeOf(Class<?> ancestorTypeRequested);
-    public BindingRequestBuilderOptionsBuildMain subtypeOfRegex(String parentTypeRegex);
-    public BindingRequestBuilderOptionsBuildMain metaAnnotationType(Class<? extends Annotation> metaAnnotationTypeRequested);
-    public BindingRequestBuilderOptionsBuildMain metaAnnotationRegex(String metaAnnotationRegex);
 
-    
+    BindingRequestBuilderOptionsBuildMain predicate(Predicate<Class<?>> classPredicate);
+    BindingRequestBuilderOptionsBuildMain annotationType(Class<? extends Annotation> annotationTypeRequested);
+    BindingRequestBuilderOptionsBuildMain annotationRegex(String annotationRegex);
+    BindingRequestBuilderOptionsBuildMain subtypeOf(Class<?> parentTypeRequested);
+    BindingRequestBuilderOptionsBuildMain subtypeOfRegex(String parentTypeRegex);
+    BindingRequestBuilderOptionsBuildMain metaAnnotationType(Class<? extends Annotation> metaAnnotationTypeRequested);
+    BindingRequestBuilderOptionsBuildMain metaAnnotationRegex(String metaAnnotationRegex);
+
 }

--- a/specs/src/main/java/io/nuun/kernel/api/predicates/ClassAnnotatedWith.java
+++ b/specs/src/main/java/io/nuun/kernel/api/predicates/ClassAnnotatedWith.java
@@ -14,38 +14,30 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.nuun.kernel.api.config;
+package io.nuun.kernel.api.predicates;
 
+import java.lang.annotation.Annotation;
+import java.util.function.Predicate;
 
-public class KernelOption<T>
+/**
+ * Strictly descendant of a candidate class.
+ * 
+ * @author ejemba
+ */
+public class ClassAnnotatedWith implements Predicate<Class<?>>
 {
-    private String name;
-    private T value;
 
-    public KernelOption(String name) {
-        this.name = name;
+    private Class<? extends Annotation> annotationClass;
+
+    public ClassAnnotatedWith(Class<? extends Annotation> annotationClass)
+    {
+        this.annotationClass = annotationClass;
     }
-
-    public KernelOption(String name, T value) {
-        this.name = name;
-        this.value = value;
-    }
-
-    public KernelOption(KernelOption<T> option, T value) {
-        this.name = option.name;
-        this.value = value == null ? option.getValue() : value;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public T getValue() {
-        return value;
-    }
-
+    
     @Override
-    public String toString() {
-        return name + ": " + value;
+    public boolean test(Class<?> candidate)
+    {
+        return candidate != null &&  candidate.isAnnotationPresent(annotationClass);
     }
+
 }

--- a/specs/src/main/java/io/nuun/kernel/api/predicates/ClassDescendantOf.java
+++ b/specs/src/main/java/io/nuun/kernel/api/predicates/ClassDescendantOf.java
@@ -14,38 +14,29 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.nuun.kernel.api.config;
+package io.nuun.kernel.api.predicates;
 
+import java.util.function.Predicate;
 
-public class KernelOption<T>
+/**
+ * Strictly descendant of a candidate class.
+ * 
+ * @author ejemba
+ */
+public class ClassDescendantOf implements Predicate<Class<?>>
 {
-    private String name;
-    private T value;
 
-    public KernelOption(String name) {
-        this.name = name;
+    private Class<?> ancestorType;
+
+    public ClassDescendantOf(Class<?> ancestorType)
+    {
+        this.ancestorType = ancestorType;
     }
-
-    public KernelOption(String name, T value) {
-        this.name = name;
-        this.value = value;
-    }
-
-    public KernelOption(KernelOption<T> option, T value) {
-        this.name = option.name;
-        this.value = value == null ? option.getValue() : value;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public T getValue() {
-        return value;
-    }
-
+    
     @Override
-    public String toString() {
-        return name + ": " + value;
+    public boolean test(Class<?> candidate)
+    {
+        return candidate != null &&  candidate != ancestorType && ancestorType.isAssignableFrom(candidate);
     }
+
 }

--- a/specs/src/main/java/io/nuun/kernel/api/predicates/ClassImplements.java
+++ b/specs/src/main/java/io/nuun/kernel/api/predicates/ClassImplements.java
@@ -14,38 +14,29 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Nuun IO Kernel Specs.  If not, see <http://www.gnu.org/licenses/>.
  */
-package io.nuun.kernel.api.config;
+package io.nuun.kernel.api.predicates;
 
+import java.util.function.Predicate;
 
-public class KernelOption<T>
+/**
+ * Strictly descendant of a candidate class.
+ * 
+ * @author ejemba
+ */
+public class ClassImplements implements Predicate<Class<?>>
 {
-    private String name;
-    private T value;
 
-    public KernelOption(String name) {
-        this.name = name;
+    private Class<?> implementedType;
+
+    public ClassImplements(Class<?> implementedType)
+    {
+        this.implementedType = implementedType;
     }
-
-    public KernelOption(String name, T value) {
-        this.name = name;
-        this.value = value;
-    }
-
-    public KernelOption(KernelOption<T> option, T value) {
-        this.name = option.name;
-        this.value = value == null ? option.getValue() : value;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public T getValue() {
-        return value;
-    }
-
+    
     @Override
-    public String toString() {
-        return name + ": " + value;
+    public boolean test(Class<?> candidate)
+    {
+        return candidate != null && implementedType.isAssignableFrom(candidate);
     }
+
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -56,13 +56,7 @@
 			<artifactId>kernel-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-<!-- 		<dependency>
-			<groupId>${project.groupId}</groupId>
-			<artifactId>nuun-log-plugin</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency> -->
-		
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITPlugin.java
+++ b/tests/src/main/java/io/nuun/kernel/tests/internal/NuunITPlugin.java
@@ -19,16 +19,16 @@ package io.nuun.kernel.tests.internal;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
+import io.nuun.kernel.api.predicates.ClassAnnotatedWith;
 import io.nuun.kernel.core.AbstractPlugin;
 import io.nuun.kernel.tests.it.NuunITRunner;
 import io.nuun.kernel.tests.it.annotations.ITBind;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
-import org.junit.runner.RunWith;
-import org.kametic.specifications.Specification;
+import java.util.function.Predicate;
 
 
 /**
@@ -41,7 +41,7 @@ public class NuunITPlugin extends AbstractPlugin
     private Collection<Class<?>> integrationTestsClass;
 
     @SuppressWarnings("unchecked")
-    private final Specification<Class<?>> iTSpecs = or(classAnnotatedWith(RunWith.class), classAnnotatedWith(ITBind.class));
+    private final Predicate<Class<?>> iTSpecs = new ClassAnnotatedWith(RunWith.class).or(new ClassAnnotatedWith(ITBind.class));
 
     @Override
     public String name() {
@@ -51,10 +51,10 @@ public class NuunITPlugin extends AbstractPlugin
     @Override
     @SuppressWarnings("rawtypes")
     public InitState init(InitContext initContext) {
-        Map<Specification, Collection<Class<?>>> scannedTypesBySpecification = initContext.scannedTypesBySpecification();
-        Collection<Class<?>> iTClassCandidates = scannedTypesBySpecification.get(iTSpecs);
+        Map<Predicate<Class<?>>, Collection<Class<?>>> scannedTypesByPredicate = initContext.scannedTypesByPredicate();
+        Collection<Class<?>> iTClassCandidates = scannedTypesByPredicate.get(iTSpecs);
         if (iTClassCandidates != null && !iTClassCandidates.isEmpty()) {
-            integrationTestsClass = new ArrayList<Class<?>>();
+            integrationTestsClass = new ArrayList<>();
             for (Class<?> itCandidate : iTClassCandidates) {
                 if (itCandidate.getAnnotation(RunWith.class) != null &&
 //                        itCandidate.getAnnotation(RunWith.class).value().equals(NuunITRunner.class)
@@ -69,7 +69,7 @@ public class NuunITPlugin extends AbstractPlugin
 
     @Override
     public Collection<ClasspathScanRequest> classpathScanRequests() {
-        return classpathScanRequestBuilder().specification(iTSpecs).build();
+        return classpathScanRequestBuilder().predicate(iTSpecs).build();
     }
 
     @Override


### PR DESCRIPTION
This PR removes Kametic specifications from the kernel, replacing them by Java 8 predicates. The intent here is to clearly separate the low-level class matching concern from the DDD specification concern. 

This opens the way to work on Kametic specifications to be DDD-only specifications.

The main side-effect is that Java 8 is now required.