### PR TITLE
Add injected() method in kernel extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# Version 1.0.M10 (???)
+# Version 1.0.M10 (2020-06-30)
 
+* [new] New `KernelExtension.injected()` method that is invoked after plugin injection but before plugin startup.   
 * [chg] The specs module is now without any dependency.
 * [brk] Class specifications have been replaced by class predicates.
 * [brk] Java 8 is now required.
 
-# Version 1.0.M8 (???)
+# Version 1.0.M8 (2016-04-22)
 
 * [new] Kernel options are centralized in `KernelOptions`
 * [new] Typed kernel configuration using `KernelOption`

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.16</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -61,12 +61,12 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>4.0</version>
+			<version>${guice.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.reflections</groupId>
 			<artifactId>reflections</artifactId>
-			<version>0.9.10</version>
+			<version>${reflections.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jsr305</artifactId>

--- a/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/ExtensionManager.java
@@ -111,6 +111,17 @@ public class ExtensionManager
     }
 
     /**
+     * Notifies the extensions that the plugins are injected
+     */
+    public void injected()
+    {
+        for (KernelExtension kernelExtension : kernelExtensions.keySet())
+        {
+            kernelExtension.injected(kernelExtensions.get(kernelExtension));
+        }
+    }
+
+    /**
      * Notifies the extensions that the kernel is started
      */
     public void started()

--- a/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
+++ b/core/src/main/java/io/nuun/kernel/core/internal/KernelCore.java
@@ -305,6 +305,10 @@ public final class KernelCore implements Kernel
         for (Plugin plugin : orderedPlugins)
         {
             mainInjector.injectMembers(plugin);
+        }
+        extensionManager.injected();
+        for (Plugin plugin : orderedPlugins)
+        {
             plugin.start(context);
         }
     }

--- a/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
+++ b/core/src/test/java/io/nuun/kernel/core/internal/ExtensionManagerIT.java
@@ -57,10 +57,11 @@ public class ExtensionManagerIT
         underTest.initializing();
         underTest.initialized();
         underTest.starting();
+        underTest.injected();
         underTest.started();
         underTest.stopping();
         underTest.stopped();
 
-        Assertions.assertThat(myKernelExtension.count).isEqualTo(111111);
+        Assertions.assertThat(myKernelExtension.count).isEqualTo(1111111);
     }
 }

--- a/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
+++ b/core/src/test/java/io/nuun/kernel/core/pluginsit/extension/MyKernelExtension.java
@@ -48,20 +48,25 @@ public class MyKernelExtension implements KernelExtension<MyExtensionInterface>
     }
 
     @Override
-    public void started(Collection<MyExtensionInterface> extensions)
-    {
+    public void injected(Collection<MyExtensionInterface> extendedPlugins) {
         count += 1000;
     }
 
     @Override
-    public void stopping(Collection<MyExtensionInterface> extensions)
+    public void started(Collection<MyExtensionInterface> extensions)
     {
         count += 10000;
     }
 
     @Override
-    public void stopped(Collection<MyExtensionInterface> extensions)
+    public void stopping(Collection<MyExtensionInterface> extensions)
     {
         count += 100000;
+    }
+
+    @Override
+    public void stopped(Collection<MyExtensionInterface> extensions)
+    {
+        count += 1000000;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,14 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
 
+        <logback.version>1.2.3</logback.version>
+        <junit.version>4.11</junit.version>
+        <assertj.version>1.7.1</assertj.version>
+        <mockito.version>1.8.5</mockito.version>
+        <powermock.version>1.5</powermock.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <guice.version>4.2.3</guice.version>
+        <reflections.version>0.9.11</reflections.version>
     </properties>
 
     <dependencies>
@@ -87,21 +95,21 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.10</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.8.5</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>1.7.1</version>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -109,20 +117,20 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
-            <version>1.0.0</version>
+            <version>${logback.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-core</artifactId>
-            <version>1.5</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>1.5</version>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
+++ b/specs/src/main/java/io/nuun/kernel/spi/KernelExtension.java
@@ -66,6 +66,13 @@ public interface KernelExtension<T>
     public void starting(Collection<T> extendedPlugins);
 
     /**
+     * Notifies the given extension that the plugins are injected.
+     *
+     * @param extendedPlugins the plugin to notify
+     */
+    public void injected(Collection<T> extendedPlugins);
+
+    /**
      * Notifies the given extension that the kernel is started.
      *
      * @param extendedPlugins the plugin to notify

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -66,21 +66,21 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>${junit.version}</version>
 			<optional>true</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.0.0</version>
+			<version>${logback.version}</version>
 			<optional>true</optional>
 		</dependency>
 
        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>1.3.0</version>
+            <version>${assertj.version}</version>
             <optional>true</optional>
         </dependency>
 


### PR DESCRIPTION
This new method is called just after plugins are injected but before their start
method is called.

This commit contains also an upgrade of all libraries to latest version except
for reflections which has some breaking changes in 0.9.12 version (it was still
upgraded to 0.9.11).